### PR TITLE
Use awx-shared code from `awx_plugins.interfaces`, not awx

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,12 +6,13 @@ honor_noqa = true
 include_trailing_comma = true
 indent = 4
 known_frameworks = awx, django
+known_platforms = awx_plugins.interfaces
 known_testing = hypothesis, pytest
 line_length = 79
 lines_after_imports = 2
 # https://pycqa.github.io/isort/#multi-line-output-modes
 multi_line_output = 3
 no_lines_before = LOCALFOLDER
-sections = FUTURE, STDLIB, TESTING, FRAMEWORKS, THIRDPARTY, FIRSTPARTY, LOCALFOLDER
+sections = FUTURE, STDLIB, TESTING, FRAMEWORKS, PLATFORMS, THIRDPARTY, FIRSTPARTY, LOCALFOLDER
 use_parentheses = true
 verbose = true

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -34,6 +34,3 @@ strict_optional = true
 warn_no_return = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-
-[mypy-awx.*]  # This can be removed once AWX can be added as a dependency or eliminated for good
-ignore_missing_imports = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -191,7 +191,6 @@ repos:
     - azure-identity  # needed by credentials.azure_kv
     - azure-keyvault  # needed by credentials.azure_kv
     - boto3-stubs  # needed by credentials.awx_secretsmanager
-    - django-stubs  # needed by credentials.injectors and inventory.plugins
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - msrestazure  # needed by credentials.azure_kv
     - pytest
@@ -218,7 +217,6 @@ repos:
     - azure-identity  # needed by credentials.azure_kv
     - azure-keyvault  # needed by credentials.azure_kv
     - boto3-stubs  # needed by credentials.awx_secretsmanager
-    - django-stubs  # needed by credentials.injectors and inventory.plugins
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - msrestazure  # needed by credentials.azure_kv
     - pytest
@@ -245,7 +243,6 @@ repos:
     - azure-identity  # needed by credentials.azure_kv
     - azure-keyvault  # needed by credentials.azure_kv
     - boto3-stubs  # needed by credentials.awx_secretsmanager
-    - django-stubs  # needed by credentials.injectors and inventory.plugins
     - lxml  # dep of `--txt-report`, `--cobertura-xml-report` & `--html-report`
     - msrestazure  # needed by credentials.azure_kv
     - pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -185,6 +185,9 @@ repos:
     alias: mypy-py313
     name: MyPy, for Python 3.13
     additional_dependencies:
+    - >-  # standard interface declarations for AWX plugins
+      awx_plugins.interfaces
+      @ git+https://github.com/ansible/awx_plugins.interfaces.git
     - azure-identity  # needed by credentials.azure_kv
     - azure-keyvault  # needed by credentials.azure_kv
     - boto3-stubs  # needed by credentials.awx_secretsmanager
@@ -209,6 +212,9 @@ repos:
     alias: mypy-py312
     name: MyPy, for Python 3.12
     additional_dependencies:
+    - >-  # standard interface declarations for AWX plugins
+      awx_plugins.interfaces
+      @ git+https://github.com/ansible/awx_plugins.interfaces.git
     - azure-identity  # needed by credentials.azure_kv
     - azure-keyvault  # needed by credentials.azure_kv
     - boto3-stubs  # needed by credentials.awx_secretsmanager
@@ -233,6 +239,9 @@ repos:
     alias: mypy-py311
     name: MyPy, for Python 3.11
     additional_dependencies:
+    - >-  # standard interface declarations for AWX plugins
+      awx_plugins.interfaces
+      @ git+https://github.com/ansible/awx_plugins.interfaces.git
     - azure-identity  # needed by credentials.azure_kv
     - azure-keyvault  # needed by credentials.azure_kv
     - boto3-stubs  # needed by credentials.awx_secretsmanager
@@ -259,6 +268,9 @@ repos:
   hooks:
   - id: pylint
     additional_dependencies:
+    - >-  # standard interface declarations for AWX plugins
+      awx_plugins.interfaces
+      @ git+https://github.com/ansible/awx_plugins.interfaces.git
     - azure-identity  # needed by credentials.azure_kv
     - azure-keyvault  # needed by credentials.azure_kv
     - boto3  # needed by credentials.awx_secretsmanager

--- a/.pylintrc.toml
+++ b/.pylintrc.toml
@@ -382,6 +382,7 @@ known-third-party = [
 
 # Couples of modules and preferred modules, separated by a comma.
 preferred-modules = [
+  "awx:awx_plugins.interfaces",
   "unittest:pytest",
 ]
 

--- a/.pylintrc.toml
+++ b/.pylintrc.toml
@@ -383,6 +383,7 @@ known-third-party = [
 # Couples of modules and preferred modules, separated by a comma.
 preferred-modules = [
   "awx:awx_plugins.interfaces",
+  "django:awx_plugins.interfaces",
   "unittest:pytest",
 ]
 

--- a/dependencies/direct/py-constraints.in
+++ b/dependencies/direct/py-constraints.in
@@ -13,3 +13,5 @@
 #      remain in Git.                                                         #
 #                                                                             #
 ###############################################################################
+
+awx_plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git

--- a/dependencies/lock-files/build-docs-cp311-darwin-arm64.txt
+++ b/dependencies/lock-files/build-docs-cp311-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/build-docs-cp311-darwin-x86_64.txt
+++ b/dependencies/lock-files/build-docs-cp311-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/build-docs-cp311-linux-x86_64.txt
+++ b/dependencies/lock-files/build-docs-cp311-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/build-docs-cp312-darwin-arm64.txt
+++ b/dependencies/lock-files/build-docs-cp312-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/build-docs-cp312-darwin-x86_64.txt
+++ b/dependencies/lock-files/build-docs-cp312-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/build-docs-cp312-linux-x86_64.txt
+++ b/dependencies/lock-files/build-docs-cp312-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/build-docs-cp313-darwin-arm64.txt
+++ b/dependencies/lock-files/build-docs-cp313-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/build-docs-cp313-darwin-x86_64.txt
+++ b/dependencies/lock-files/build-docs-cp313-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/build-docs-cp313-linux-x86_64.txt
+++ b/dependencies/lock-files/build-docs-cp313-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/coverage-docs-cp311-darwin-arm64.txt
+++ b/dependencies/lock-files/coverage-docs-cp311-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/coverage-docs-cp311-darwin-x86_64.txt
+++ b/dependencies/lock-files/coverage-docs-cp311-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/coverage-docs-cp311-linux-x86_64.txt
+++ b/dependencies/lock-files/coverage-docs-cp311-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/coverage-docs-cp312-darwin-arm64.txt
+++ b/dependencies/lock-files/coverage-docs-cp312-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/coverage-docs-cp312-darwin-x86_64.txt
+++ b/dependencies/lock-files/coverage-docs-cp312-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/coverage-docs-cp312-linux-x86_64.txt
+++ b/dependencies/lock-files/coverage-docs-cp312-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/coverage-docs-cp313-darwin-arm64.txt
+++ b/dependencies/lock-files/coverage-docs-cp313-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/coverage-docs-cp313-darwin-x86_64.txt
+++ b/dependencies/lock-files/coverage-docs-cp313-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/coverage-docs-cp313-linux-x86_64.txt
+++ b/dependencies/lock-files/coverage-docs-cp313-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/doctest-docs-cp311-darwin-arm64.txt
+++ b/dependencies/lock-files/doctest-docs-cp311-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/doctest-docs-cp311-darwin-x86_64.txt
+++ b/dependencies/lock-files/doctest-docs-cp311-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/doctest-docs-cp311-linux-x86_64.txt
+++ b/dependencies/lock-files/doctest-docs-cp311-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/doctest-docs-cp312-darwin-arm64.txt
+++ b/dependencies/lock-files/doctest-docs-cp312-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/doctest-docs-cp312-darwin-x86_64.txt
+++ b/dependencies/lock-files/doctest-docs-cp312-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/doctest-docs-cp312-linux-x86_64.txt
+++ b/dependencies/lock-files/doctest-docs-cp312-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/doctest-docs-cp313-darwin-arm64.txt
+++ b/dependencies/lock-files/doctest-docs-cp313-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/doctest-docs-cp313-darwin-x86_64.txt
+++ b/dependencies/lock-files/doctest-docs-cp313-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/doctest-docs-cp313-linux-x86_64.txt
+++ b/dependencies/lock-files/doctest-docs-cp313-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/linkcheck-docs-cp311-darwin-arm64.txt
+++ b/dependencies/lock-files/linkcheck-docs-cp311-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/linkcheck-docs-cp311-darwin-x86_64.txt
+++ b/dependencies/lock-files/linkcheck-docs-cp311-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/linkcheck-docs-cp311-linux-x86_64.txt
+++ b/dependencies/lock-files/linkcheck-docs-cp311-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/linkcheck-docs-cp312-darwin-arm64.txt
+++ b/dependencies/lock-files/linkcheck-docs-cp312-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/linkcheck-docs-cp312-darwin-x86_64.txt
+++ b/dependencies/lock-files/linkcheck-docs-cp312-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/linkcheck-docs-cp312-linux-x86_64.txt
+++ b/dependencies/lock-files/linkcheck-docs-cp312-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/linkcheck-docs-cp313-darwin-arm64.txt
+++ b/dependencies/lock-files/linkcheck-docs-cp313-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/linkcheck-docs-cp313-darwin-x86_64.txt
+++ b/dependencies/lock-files/linkcheck-docs-cp313-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/linkcheck-docs-cp313-linux-x86_64.txt
+++ b/dependencies/lock-files/linkcheck-docs-cp313-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/py311-cp311-darwin-arm64.txt
+++ b/dependencies/lock-files/py311-cp311-darwin-arm64.txt
@@ -10,6 +10,10 @@ asgiref==3.8.1
     # via django
 attrs==24.2.0
     # via hypothesis
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/py311-cp311-darwin-x86_64.txt
+++ b/dependencies/lock-files/py311-cp311-darwin-x86_64.txt
@@ -10,6 +10,10 @@ asgiref==3.8.1
     # via django
 attrs==24.2.0
     # via hypothesis
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/py311-cp311-linux-x86_64.txt
+++ b/dependencies/lock-files/py311-cp311-linux-x86_64.txt
@@ -10,6 +10,10 @@ asgiref==3.8.1
     # via django
 attrs==24.2.0
     # via hypothesis
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/py312-cp312-darwin-arm64.txt
+++ b/dependencies/lock-files/py312-cp312-darwin-arm64.txt
@@ -10,6 +10,10 @@ asgiref==3.8.1
     # via django
 attrs==24.2.0
     # via hypothesis
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/py312-cp312-darwin-x86_64.txt
+++ b/dependencies/lock-files/py312-cp312-darwin-x86_64.txt
@@ -10,6 +10,10 @@ asgiref==3.8.1
     # via django
 attrs==24.2.0
     # via hypothesis
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/py312-cp312-linux-x86_64.txt
+++ b/dependencies/lock-files/py312-cp312-linux-x86_64.txt
@@ -10,6 +10,10 @@ asgiref==3.8.1
     # via django
 attrs==24.2.0
     # via hypothesis
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/py313-cp313-darwin-arm64.txt
+++ b/dependencies/lock-files/py313-cp313-darwin-arm64.txt
@@ -10,6 +10,10 @@ asgiref==3.8.1
     # via django
 attrs==24.2.0
     # via hypothesis
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/py313-cp313-darwin-x86_64.txt
+++ b/dependencies/lock-files/py313-cp313-darwin-x86_64.txt
@@ -10,6 +10,10 @@ asgiref==3.8.1
     # via django
 attrs==24.2.0
     # via hypothesis
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/py313-cp313-linux-x86_64.txt
+++ b/dependencies/lock-files/py313-cp313-linux-x86_64.txt
@@ -10,6 +10,10 @@ asgiref==3.8.1
     # via django
 attrs==24.2.0
     # via hypothesis
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/spellcheck-docs-cp311-darwin-arm64.txt
+++ b/dependencies/lock-files/spellcheck-docs-cp311-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/spellcheck-docs-cp311-darwin-x86_64.txt
+++ b/dependencies/lock-files/spellcheck-docs-cp311-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/spellcheck-docs-cp311-linux-x86_64.txt
+++ b/dependencies/lock-files/spellcheck-docs-cp311-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/spellcheck-docs-cp312-darwin-arm64.txt
+++ b/dependencies/lock-files/spellcheck-docs-cp312-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/spellcheck-docs-cp312-darwin-x86_64.txt
+++ b/dependencies/lock-files/spellcheck-docs-cp312-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/spellcheck-docs-cp312-linux-x86_64.txt
+++ b/dependencies/lock-files/spellcheck-docs-cp312-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/spellcheck-docs-cp313-darwin-arm64.txt
+++ b/dependencies/lock-files/spellcheck-docs-cp313-darwin-arm64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/spellcheck-docs-cp313-darwin-x86_64.txt
+++ b/dependencies/lock-files/spellcheck-docs-cp313-darwin-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/dependencies/lock-files/spellcheck-docs-cp313-linux-x86_64.txt
+++ b/dependencies/lock-files/spellcheck-docs-cp313-linux-x86_64.txt
@@ -10,6 +10,10 @@ alabaster==1.0.0
     # via sphinx
 asgiref==3.8.1
     # via django
+awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+    # via
+    #   -c dependencies/direct/py-constraints.in
+    #   awx-plugins-core (pyproject.toml)
 azure-core==1.31.0
     # via
     #   azure-identity

--- a/nitpick-style.toml
+++ b/nitpick-style.toml
@@ -67,13 +67,14 @@ honor_noqa = true
 include_trailing_comma = true
 indent = 4
 known_frameworks = 'awx, django'
+known_platforms = 'awx_plugins.interfaces'
 known_testing = 'hypothesis, pytest'
 line_length = 79
 lines_after_imports = 2
 # https://pycqa.github.io/isort/#multi-line-output-modes
 multi_line_output = 3
 no_lines_before = 'LOCALFOLDER'
-sections = 'FUTURE, STDLIB, TESTING, FRAMEWORKS, THIRDPARTY, FIRSTPARTY, LOCALFOLDER'
+sections = 'FUTURE, STDLIB, TESTING, FRAMEWORKS, PLATFORMS, THIRDPARTY, FIRSTPARTY, LOCALFOLDER'
 use_parentheses = true
 verbose = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [  # runtime deps  # https://packaging.python.org/en/latest/guide
   # GUIDANCE: only add things that this project imports directly
   # GUIDANCE: only set lower version bounds
   # "awx_plugins.base_interface.api",  # keep `__init__.py` empty
+  "awx_plugins.interfaces",  # standard interface declarations for AWX plugins
   "Django",  # <- credentials.injectors (and inventory.plugins indirectly)
   "PyYAML",  # credentials.injectors, inventory.plugins
   "azure-identity",  # credentials.azure_kv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [  # runtime deps  # https://packaging.python.org/en/latest/guide
   # GUIDANCE: only set lower version bounds
   # "awx_plugins.base_interface.api",  # keep `__init__.py` empty
   "awx_plugins.interfaces",  # standard interface declarations for AWX plugins
-  "Django",  # <- credentials.injectors (and inventory.plugins indirectly)
   "PyYAML",  # credentials.injectors, inventory.plugins
   "azure-identity",  # credentials.azure_kv
   "azure-keyvault",  # credentials.azure_kv

--- a/src/awx_plugins/credentials/aim.py
+++ b/src/awx_plugins/credentials/aim.py
@@ -3,14 +3,13 @@
 
 from urllib.parse import quote, urlencode, urljoin
 
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
 import requests
 
-from .plugin import (
-    CertFiles,
-    CredentialPlugin,
-    raise_for_status,
-    translate_function as _,
-)
+from .plugin import CertFiles, CredentialPlugin, raise_for_status
 
 
 aim_inputs = {

--- a/src/awx_plugins/credentials/aws_secretsmanager.py
+++ b/src/awx_plugins/credentials/aws_secretsmanager.py
@@ -1,10 +1,14 @@
 # FIXME: the following violations must be addressed gradually and unignored
 # mypy: disable-error-code="no-untyped-def"
 
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
 import boto3
 from botocore.exceptions import ClientError
 
-from .plugin import CredentialPlugin, translate_function as _
+from .plugin import CredentialPlugin
 
 
 secrets_manager_inputs = {

--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -1,11 +1,15 @@
 # FIXME: the following violations must be addressed gradually and unignored
 # mypy: disable-error-code="import-untyped, no-untyped-def"
 
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
 from azure.identity import ClientSecretCredential
 from azure.keyvault.secrets import SecretClient
 from msrestazure import azure_cloud
 
-from .plugin import CredentialPlugin, translate_function as _
+from .plugin import CredentialPlugin
 
 
 # https://github.com/Azure/msrestazure-for-python/blob/master/msrestazure/azure_cloud.py

--- a/src/awx_plugins/credentials/centrify_vault.py
+++ b/src/awx_plugins/credentials/centrify_vault.py
@@ -3,9 +3,13 @@
 
 from urllib.parse import urljoin
 
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
 import requests
 
-from .plugin import CredentialPlugin, raise_for_status, translate_function as _
+from .plugin import CredentialPlugin, raise_for_status
 
 
 pas_inputs = {

--- a/src/awx_plugins/credentials/conjur.py
+++ b/src/awx_plugins/credentials/conjur.py
@@ -5,14 +5,13 @@ import base64
 import binascii
 from urllib.parse import quote, urljoin
 
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
 import requests
 
-from .plugin import (
-    CertFiles,
-    CredentialPlugin,
-    raise_for_status,
-    translate_function as _,
-)
+from .plugin import CertFiles, CredentialPlugin, raise_for_status
 
 
 conjur_inputs = {

--- a/src/awx_plugins/credentials/dsv.py
+++ b/src/awx_plugins/credentials/dsv.py
@@ -3,9 +3,13 @@
 
 from base64 import b64decode
 
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
 from delinea.secrets.vault import PasswordGrantAuthorizer, SecretsVault
 
-from .plugin import CredentialPlugin, settings, translate_function as _
+from .plugin import CredentialPlugin, settings
 
 
 dsv_inputs = {

--- a/src/awx_plugins/credentials/hashivault.py
+++ b/src/awx_plugins/credentials/hashivault.py
@@ -7,14 +7,13 @@ import pathlib
 import time
 from urllib.parse import urljoin
 
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
 import requests
 
-from .plugin import (
-    CertFiles,
-    CredentialPlugin,
-    raise_for_status,
-    translate_function as _,
-)
+from .plugin import CertFiles, CredentialPlugin, raise_for_status
 
 
 base_inputs = {

--- a/src/awx_plugins/credentials/injectors.py
+++ b/src/awx_plugins/credentials/injectors.py
@@ -5,14 +5,13 @@ import json
 import os
 import stat
 import tempfile
-from contextlib import suppress as _suppress_exception
 
 from awx_plugins.interfaces._temporary_private_container_api import (  # noqa: WPS436
     get_incontainer_path,
 )
-
-with _suppress_exception(ImportError):
-    from django.conf import settings
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    get_vmware_certificate_validation_setting,
+)
 
 import yaml
 
@@ -89,7 +88,9 @@ def vmware(cred, env, private_data_dir):
     env['VMWARE_USER'] = cred.get_input('username', default='')
     env['VMWARE_PASSWORD'] = cred.get_input('password', default='')
     env['VMWARE_HOST'] = cred.get_input('host', default='')
-    env['VMWARE_VALIDATE_CERTS'] = str(settings.VMWARE_VALIDATE_CERTS)
+    env['VMWARE_VALIDATE_CERTS'] = str(
+        get_vmware_certificate_validation_setting(),
+    )
 
 
 def _openstack_data(cred):

--- a/src/awx_plugins/credentials/plugin.py
+++ b/src/awx_plugins/credentials/plugin.py
@@ -15,12 +15,6 @@ CredentialPlugin = namedtuple(
 )
 
 
-try:
-    from django.utils.translation import gettext_lazy as translate_function
-except ModuleNotFoundError:
-    translate_function = lambda *args, **kwargs: None
-
-
 class Settings():
     DEBUG = False
 

--- a/src/awx_plugins/credentials/plugins.py
+++ b/src/awx_plugins/credentials/plugins.py
@@ -1,20 +1,11 @@
 # FIXME: the following violations must be addressed gradually and unignored
 # mypy: disable-error-code="assignment, misc, no-redef"
 
-from __future__ import annotations
-
-
-try:
-    # Django
-    from django.utils.translation import gettext_noop
-except ImportError:
-    # FIXME: stop suppressing once the circular dependency is untangled
-    # FIXME: these stubs are temporary
-    def gettext_noop(_text: str) -> str:
-        """Emulate a Django-imported no-op."""  # noqa: DAR201; FIXME
-        return _text
 from awx_plugins.interfaces._temporary_private_api import (  # noqa: WPS436
     ManagedCredentialType,
+)
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop,
 )
 
 

--- a/src/awx_plugins/credentials/plugins.py
+++ b/src/awx_plugins/credentials/plugins.py
@@ -6,28 +6,16 @@ from __future__ import annotations
 
 try:
     # Django
-    # AWX
-    from awx.main.models.credential import ManagedCredentialType
     from django.utils.translation import gettext_noop
 except ImportError:
     # FIXME: stop suppressing once the circular dependency is untangled
     # FIXME: these stubs are temporary
-    from dataclasses import dataclass
-
-    @dataclass(frozen=True)
-    class ManagedCredentialType:
-        """Managed credential type stub."""
-
-        namespace: str
-        name: str
-        kind: str
-        inputs: dict[str, list[dict[str, bool | str] | str]]
-        injectors: dict[str, dict[str, str]] = None
-        managed: bool = False
-
     def gettext_noop(_text: str) -> str:
         """Emulate a Django-imported no-op."""  # noqa: DAR201; FIXME
         return _text
+from awx_plugins.interfaces._temporary_private_api import (  # noqa: WPS436
+    ManagedCredentialType,
+)
 
 
 ManagedCredentialType(

--- a/src/awx_plugins/credentials/tss.py
+++ b/src/awx_plugins/credentials/tss.py
@@ -1,7 +1,11 @@
 # FIXME: the following violations must be addressed gradually and unignored
 # mypy: disable-error-code="no-untyped-def, import-not-found, import-untyped"
 
-from .plugin import CredentialPlugin, translate_function as _
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
+from .plugin import CredentialPlugin
 
 
 try:

--- a/src/awx_plugins/inventory/plugins.py
+++ b/src/awx_plugins/inventory/plugins.py
@@ -4,16 +4,13 @@
 import os.path
 import stat
 import tempfile
-from contextlib import suppress as _suppress_exception
 
+from awx_plugins.interfaces._temporary_private_container_api import (  # noqa: WPS436
+    get_incontainer_path,
+)
 from awx_plugins.interfaces._temporary_private_licensing_api import (  # noqa: WPS436
     detect_server_product_name,
 )
-
-
-with _suppress_exception(ImportError):
-    # FIXME: stop suppressing once the circular dependency is untangled
-    from awx.main.utils.execution_environments import to_container_path
 
 import yaml
 
@@ -270,7 +267,7 @@ class openstack(PluginFileInjector):
         )
         credential = inventory_update.get_cloud_credential()
         cred_data = private_data_files['credentials']
-        env['OS_CLIENT_CONFIG_FILE'] = to_container_path(
+        env['OS_CLIENT_CONFIG_FILE'] = get_incontainer_path(
             cred_data[credential], private_data_dir,
         )
         return env
@@ -337,7 +334,7 @@ class terraform(PluginFileInjector):
             with os.fdopen(handle, 'w') as f:
                 os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
                 f.write(config_cred)
-            ret['backend_config_files'] = to_container_path(
+            ret['backend_config_files'] = get_incontainer_path(
                 path, private_data_dir,
             )
         return ret
@@ -365,7 +362,7 @@ class terraform(PluginFileInjector):
         credential = inventory_update.get_cloud_credential()
         cred_data = private_data_files['credentials']
         if credential in cred_data:
-            env['GOOGLE_BACKEND_CREDENTIALS'] = to_container_path(
+            env['GOOGLE_BACKEND_CREDENTIALS'] = get_incontainer_path(
                 cred_data[credential], private_data_dir,
             )
         return env

--- a/src/awx_plugins/inventory/plugins.py
+++ b/src/awx_plugins/inventory/plugins.py
@@ -6,11 +6,14 @@ import stat
 import tempfile
 from contextlib import suppress as _suppress_exception
 
+from awx_plugins.interfaces._temporary_private_licensing_api import (  # noqa: WPS436
+    detect_server_product_name,
+)
+
 
 with _suppress_exception(ImportError):
     # FIXME: stop suppressing once the circular dependency is untangled
     from awx.main.utils.execution_environments import to_container_path
-    from awx.main.utils.licensing import server_product_name
 
 import yaml
 
@@ -63,7 +66,7 @@ class PluginFileInjector:
             if hasattr(
                     self,
                     'downstream_namespace',
-            ) and server_product_name() != 'AWX':
+            ) and detect_server_product_name() != 'AWX':
                 source_vars['plugin'] = f"""{
                     self.downstream_namespace
                 }.{


### PR DESCRIPTION
This contributes to removing the circular dependency between `awx-plugins-core` and `awx`.