### PR TITLE
Hide GET params that contain senstive data from error output

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -123,7 +123,7 @@ per-file-ignores =
   src/awx_plugins/credentials/plugins.py: B950,D100, D101, D103, D105, D107, D205, D400, LN001, WPS204, WPS229, WPS433, WPS440
   src/awx_plugins/credentials/tss.py: ANN003, ANN201, D100, D103, E712, WPS433, WPS440, WPS503
   src/awx_plugins/inventory/plugins.py: ANN001, ANN002, ANN003, ANN101, ANN102, ANN201, ANN202, ANN206, B950, C812, C819, D100, D101, D102, D205, D209, D400, D401, LN001, LN002, N801, WPS110, WPS111, WPS202, WPS210, WPS214, WPS301, WPS319, WPS324, WPS331, WPS336, WPS337, WPS338, WPS347, WPS421, WPS433, WPS450, WPS510, WPS529
-  tests/credential_plugins_test.py: ANN101, B017, C419, D100, D102, D103, D205, D209, D400, DAR, PT011, S105, WPS111, WPS117, WPS118, WPS202, WPS352, WPS421, WPS433, WPS507
+  tests/credential_plugins_test.py: ANN101, B017, C419, D100, D102, D103, D205, D209, D400, DAR, PT011, S105, WPS111, WPS117, WPS118, WPS202, WPS352, WPS421, WPS433, WPS507, WPS441
   tests/importable_test.py: ANN101, DAR
 
 # Count the number of occurrences of each error/warning code and print a report:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [  # runtime deps  # https://packaging.python.org/en/latest/guide
   # GUIDANCE: only add things that this project imports directly
   # GUIDANCE: only set lower version bounds
   # "awx_plugins.base_interface.api",  # keep `__init__.py` empty
-  "awx_plugins.interfaces",  # standard interface declarations for AWX plugins
+  "awx_plugins.interfaces @git+https://github.com/ansible/awx_plugins.interfaces.git@ad4a965",  # standard interface declarations for AWX plugins
   "PyYAML",  # credentials.injectors, inventory.plugins
   "azure-identity",  # credentials.azure_kv
   "azure-keyvault",  # credentials.azure_kv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [  # runtime deps  # https://packaging.python.org/en/latest/guide
   # GUIDANCE: only add things that this project imports directly
   # GUIDANCE: only set lower version bounds
   # "awx_plugins.base_interface.api",  # keep `__init__.py` empty
-  "awx_plugins.interfaces @git+https://github.com/ansible/awx_plugins.interfaces.git@ad4a965",  # standard interface declarations for AWX plugins
+  "awx_plugins.interfaces",  # standard interface declarations for AWX plugins
   "PyYAML",  # credentials.injectors, inventory.plugins
   "azure-identity",  # credentials.azure_kv
   "azure-keyvault",  # credentials.azure_kv

--- a/src/awx_plugins/credentials/aim.py
+++ b/src/awx_plugins/credentials/aim.py
@@ -7,7 +7,7 @@ from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS4
     gettext_noop as _,
 )
 
-import requests
+import requests as requests
 
 from .plugin import CertFiles, CredentialPlugin, raise_for_status
 

--- a/src/awx_plugins/credentials/aim.py
+++ b/src/awx_plugins/credentials/aim.py
@@ -112,14 +112,18 @@ def aim_backend(**kwargs):
             allow_redirects=False,
         )
     sensitive_query_params = {
-        'AppId' : "****",
-        'Query' : "****",
-        'QueryFormat' : object_query_format,   
+        'AppId': '****',
+        'Query': '****',
+        'QueryFormat': object_query_format,
     }
     if reason:
-        sensitive_query_params['reason'] = "****"
-    sensitive_request_qs = '?' + urlencode(sensitive_query_params, safe="*", quote_via=quote)
-    res.url = request_url + sensitive_request_qs
+        sensitive_query_params['reason'] = '****'
+    sensitive_request_qs = urlencode(
+        sensitive_query_params,
+        safe='*',
+        quote_via=quote,
+    )
+    res.url = f'{request_url}?{sensitive_request_qs}'
 
     raise_for_status(res)
     # CCP returns the property name capitalized, username is camel case

--- a/src/awx_plugins/credentials/aim.py
+++ b/src/awx_plugins/credentials/aim.py
@@ -111,6 +111,16 @@ def aim_backend(**kwargs):
             verify=verify,
             allow_redirects=False,
         )
+    sensitive_query_params = {
+        'AppId' : "****",
+        'Query' : "****",
+        'QueryFormat' : object_query_format,   
+    }
+    if reason:
+        sensitive_query_params['reason'] = "****"
+    sensitive_request_qs = '?' + urlencode(sensitive_query_params, safe="*", quote_via=quote)
+    res.url = request_url + sensitive_request_qs
+
     raise_for_status(res)
     # CCP returns the property name capitalized, username is camel case
     # so we need to handle that case

--- a/tests/credential_plugins_test.py
+++ b/tests/credential_plugins_test.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 
 from awx_plugins.credentials import hashivault
-
+from awx_plugins.credentials import aim
 
 def test_imported_azure_cloud_sdk_vars() -> None:
     from awx_plugins.credentials import azure_kv
@@ -162,3 +162,12 @@ class TestDelineaImports:
         ):
             # assert this module as opposed to older thycotic.secrets.server
             assert cls.__module__ == 'delinea.secrets.server'
+
+def test_aim_sensitive_traceback():
+    aim.aim_backend(
+        url='https://google.com',
+        app_id='test',
+        object_query='test',
+        object_query_format='test',
+        verify=True,
+    )

--- a/tests/credential_plugins_test.py
+++ b/tests/credential_plugins_test.py
@@ -176,8 +176,12 @@ def test_aim_sensitive_traceback_masked(
     my_response.status_code = 404
     my_response.url = 'not_found'
 
-    monkeypatch.setattr(aim.requests, 'get', mocker.Mock(name='aim_request'))
-    aim.requests.get.return_value = my_response
+    aim_request_mock = mocker.Mock(
+        autospec=True,
+        name='aim_request',
+        return_value=my_response,
+    )
+    monkeypatch.setattr(aim.requests, 'get', aim_request_mock)
 
     expected_url_in_exc = (
         r'.*http://testurl\.com/AIMWebService/api/Accounts\?'
@@ -188,7 +192,10 @@ def test_aim_sensitive_traceback_masked(
         'AppId=****&Query=****&QueryFormat=test&reason=****'
     )
 
-    with pytest.raises(requests.exceptions.HTTPError, match=expected_url_in_exc) as e:
+    with pytest.raises(
+        requests.exceptions.HTTPError,
+        match=expected_url_in_exc,
+    ) as e:
         aim.aim_backend(
             url='http://testurl.com',
             app_id='foobar123',
@@ -198,5 +205,5 @@ def test_aim_sensitive_traceback_masked(
             verify=True,
         )
 
-    assert e._excinfo[1].response.url == expected_response_url_literal
+    assert e.value.response.url == expected_response_url_literal
     assert 'foobar123' not in str(e)

--- a/tests/credential_plugins_test.py
+++ b/tests/credential_plugins_test.py
@@ -5,8 +5,11 @@ from unittest import mock
 
 import pytest
 
-from awx_plugins.credentials import hashivault
-from awx_plugins.credentials import aim
+import requests
+from pytest_mock import MockerFixture
+
+from awx_plugins.credentials import aim, hashivault
+
 
 def test_imported_azure_cloud_sdk_vars() -> None:
     from awx_plugins.credentials import azure_kv
@@ -163,11 +166,34 @@ class TestDelineaImports:
             # assert this module as opposed to older thycotic.secrets.server
             assert cls.__module__ == 'delinea.secrets.server'
 
-def test_aim_sensitive_traceback():
-    aim.aim_backend(
-        url='https://google.com',
-        app_id='test',
-        object_query='test',
-        object_query_format='test',
-        verify=True,
+
+def test_aim_sensitive_traceback_masked(mocker: MockerFixture) -> None:
+    """Ensure that the sensitive information is not leaked in the traceback."""
+    my_response = requests.Response()
+    my_response.status_code = 404
+    my_response.url = 'not_found'
+
+    aim.requests.get = mocker.Mock(name='aim_request')
+    aim.requests.get.return_value = my_response
+
+    expected_url_in_exc = (
+        r'.*http://testurl\.com/AIMWebService/api/Accounts\?'
+        r'AppId=\*\*\*\*&Query=\*\*\*\*&QueryFormat=test&reason=\*\*\*\*.*'
     )
+    expected_response_url_literal = (
+        'http://testurl.com/AIMWebService/api/Accounts?'
+        'AppId=****&Query=****&QueryFormat=test&reason=****'
+    )
+
+    with pytest.raises(requests.exceptions.HTTPError, match=expected_url_in_exc) as e:
+        aim.aim_backend(
+            url='http://testurl.com',
+            app_id='foobar123',
+            object_query='foobar123',
+            object_query_format='test',
+            reason='foobar123',
+            verify=True,
+        )
+
+    assert e._excinfo[1].response.url == expected_response_url_literal
+    assert 'foobar123' not in str(e)

--- a/tests/credential_plugins_test.py
+++ b/tests/credential_plugins_test.py
@@ -167,13 +167,16 @@ class TestDelineaImports:
             assert cls.__module__ == 'delinea.secrets.server'
 
 
-def test_aim_sensitive_traceback_masked(mocker: MockerFixture) -> None:
+def test_aim_sensitive_traceback_masked(
+        mocker: MockerFixture,
+        monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ensure that the sensitive information is not leaked in the traceback."""
     my_response = requests.Response()
     my_response.status_code = 404
     my_response.url = 'not_found'
 
-    aim.requests.get = mocker.Mock(name='aim_request')
+    monkeypatch.setattr(aim.requests, 'get', mocker.Mock(name='aim_request'))
     aim.requests.get.return_value = my_response
 
     expected_url_in_exc = (


### PR DESCRIPTION
Currently, the AIM plugin is showing AppID, Object_Query and reason in the constructed URL when an error is throw and streamed back to stdout. This PR will hide those GET params from being displayed. 