### PR TITLE
Work around docutils v0.21.2 deprecation issue

### DIFF
--- a/dependencies/direct/py-constraints.in
+++ b/dependencies/direct/py-constraints.in
@@ -15,3 +15,4 @@
 ###############################################################################
 
 awx_plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+sphinx-autodoc-typehints @ git+https://github.com/tox-dev/sphinx-autodoc-typehints.git@6c151583fb898731ebdb10bd6c36c2731fdd6180 # Workaround for docutils 0.21.2 while waiting for the fix to land in sphinx-autodoc-typehints 2.5.x release stream https://github.com/tox-dev/sphinx-autodoc-typehints/issues/454


### PR DESCRIPTION
* A deprecation warning in docutils surfaces through sphinx-autodoc-typehints. A workaround was submitted to sphinx-autodoc-typehints but that workaround/fix is not yet in a release version. More background info can be found here
https://github.com/tox-dev/sphinx-autodoc-typehints/issues/454

Maybe this PR will trigger some pip deps lock file magic, magic I'll have to do it in the CI. Gotta start somewhere.