### PR TITLE
Add client_id and client_secret fields to Insights credential

### DIFF
--- a/src/awx_plugins/credentials/plugins.py
+++ b/src/awx_plugins/credentials/plugins.py
@@ -586,16 +586,16 @@ insights = ManagedCredentialType(
     inputs={
         'fields': [
             {
-                'id': 'username', 'label': gettext_noop('Username'), 'type': 'string',
+                'id': 'username', 'label': gettext_noop('Username'), 'type': 'string', 'help_text': gettext_noop('Required for basic authentication'),
             },
             {
-                'id': 'password', 'label': gettext_noop('Password'), 'type': 'string', 'secret': True,
+                'id': 'password', 'label': gettext_noop('Password'), 'type': 'string', 'secret': True, 'help_text': gettext_noop('Required for basic authentication'),
             },
             {
-                'id': 'client_id', 'label': gettext_noop('Client ID'), 'type': 'string',
+                'id': 'client_id', 'label': gettext_noop('Client ID'), 'type': 'string', 'help_text': gettext_noop('Alternative to username and password. Required for service account authentication'),
             },
             {
-                'id': 'client_secret', 'label': gettext_noop('Client Secret'), 'type': 'string', 'secret': True,
+                'id': 'client_secret', 'label': gettext_noop('Client Secret'), 'type': 'string', 'secret': True, 'help_text': gettext_noop('Alternative to username and password. Required for service account authentication'),
             }
         ],
         'required': [],

--- a/src/awx_plugins/credentials/plugins.py
+++ b/src/awx_plugins/credentials/plugins.py
@@ -591,6 +591,12 @@ insights = ManagedCredentialType(
             {
                 'id': 'password', 'label': gettext_noop('Password'), 'type': 'string', 'secret': True,
             },
+            {
+                'id': 'client_id', 'label': gettext_noop('Client_ID'), 'type': 'string',
+            },
+            {
+                'id': 'client_secret', 'label': gettext_noop('Client_Secret'), 'type': 'string', 'secret': True,
+            }
         ],
         'required': ['username', 'password'],
     },
@@ -598,10 +604,15 @@ insights = ManagedCredentialType(
         'extra_vars': {
             'scm_username': '{{username}}',
             'scm_password': '{{password}}',
+            'client_id': '{{client_id}}',
+            'client_secret': '{{client_secret}}',
+            'authentication': '{% if client_id %}service_account{% else %}basic{% endif %}',
         },
         'env': {
             'INSIGHTS_USER': '{{username}}',
             'INSIGHTS_PASSWORD': '{{password}}',
+            'INSIGHTS_CLIENT_ID': '{{client_id}}',
+            'INSIGHTS_CLIENT_SECRET': '{{client_secret}}',
         },
     },
 )

--- a/src/awx_plugins/credentials/plugins.py
+++ b/src/awx_plugins/credentials/plugins.py
@@ -578,44 +578,48 @@ bitbucket_dc_token = ManagedCredentialType(
     },
 )
 
-insights = ManagedCredentialType(
-    namespace='insights',
-    kind='insights',
-    name=gettext_noop('Insights'),
-    managed=True,
-    inputs={
-        'fields': [
-            {
-                'id': 'username', 'label': gettext_noop('Username'), 'type': 'string', 'help_text': gettext_noop('Required for basic authentication'),
-            },
-            {
-                'id': 'password', 'label': gettext_noop('Password'), 'type': 'string', 'secret': True, 'help_text': gettext_noop('Required for basic authentication'),
-            },
-            {
-                'id': 'client_id', 'label': gettext_noop('Client ID'), 'type': 'string', 'help_text': gettext_noop('Alternative to username and password. Required for service account authentication'),
-            },
-            {
-                'id': 'client_secret', 'label': gettext_noop('Client Secret'), 'type': 'string', 'secret': True, 'help_text': gettext_noop('Alternative to username and password. Required for service account authentication'),
-            }
-        ],
-        'required': [],
-    },
-    injectors={
-        'extra_vars': {
-            'scm_username': '{{username}}',
-            'scm_password': '{{password}}',
-            'client_id': '{{client_id}}',
-            'client_secret': '{{client_secret}}',
-            'authentication': '{% if client_id %}service_account{% else %}basic{% endif %}',
-        },
-        'env': {
-            'INSIGHTS_USER': '{{username}}',
-            'INSIGHTS_PASSWORD': '{{password}}',
-            'INSIGHTS_CLIENT_ID': '{{client_id}}',
-            'INSIGHTS_CLIENT_SECRET': '{{client_secret}}',
-        },
-    },
-)
+insights = ManagedCredentialType(namespace='insights',
+                                 kind='insights',
+                                 name=gettext_noop('Insights'),
+                                 managed=True,
+                                 inputs={'fields': [{'id': 'username',
+                                                     'label': gettext_noop('Username'),
+                                                     'type': 'string',
+                                                     'help_text': gettext_noop('Required for basic authentication'),
+                                                     },
+                                                    {'id': 'password',
+                                                     'label': gettext_noop('Password'),
+                                                     'type': 'string',
+                                                     'secret': True,
+                                                     'help_text': gettext_noop('Required for basic authentication'),
+                                                     },
+                                                    {'id': 'client_id',
+                                                     'label': gettext_noop('Client ID'),
+                                                     'type': 'string',
+                                                     'help_text': gettext_noop('Alternative to username and password. Required for service account authentication'),
+                                                     },
+                                                    {'id': 'client_secret',
+                                                     'label': gettext_noop('Client Secret'),
+                                                     'type': 'string',
+                                                     'secret': True,
+                                                     'help_text': gettext_noop('Alternative to username and password. Required for service account authentication'),
+                                                     },
+                                                    ],
+                                         'required': [],
+                                         },
+                                 injectors={'extra_vars': {'scm_username': '{{username}}',
+                                                           'scm_password': '{{password}}',
+                                                           'client_id': '{{client_id}}',
+                                                           'client_secret': '{{client_secret}}',
+                                                           'authentication': '{% if client_id %}service_account{% else %}basic{% endif %}',
+                                                           },
+                                            'env': {'INSIGHTS_USER': '{{username}}',
+                                                    'INSIGHTS_PASSWORD': '{{password}}',
+                                                    'INSIGHTS_CLIENT_ID': '{{client_id}}',
+                                                    'INSIGHTS_CLIENT_SECRET': '{{client_secret}}',
+                                                    },
+                                            },
+                                 )
 
 rhv = ManagedCredentialType(
     namespace='rhv',

--- a/src/awx_plugins/credentials/plugins.py
+++ b/src/awx_plugins/credentials/plugins.py
@@ -578,48 +578,70 @@ bitbucket_dc_token = ManagedCredentialType(
     },
 )
 
-insights = ManagedCredentialType(namespace='insights',
-                                 kind='insights',
-                                 name=gettext_noop('Insights'),
-                                 managed=True,
-                                 inputs={'fields': [{'id': 'username',
-                                                     'label': gettext_noop('Username'),
-                                                     'type': 'string',
-                                                     'help_text': gettext_noop('Required for basic authentication'),
-                                                     },
-                                                    {'id': 'password',
-                                                     'label': gettext_noop('Password'),
-                                                     'type': 'string',
-                                                     'secret': True,
-                                                     'help_text': gettext_noop('Required for basic authentication'),
-                                                     },
-                                                    {'id': 'client_id',
-                                                     'label': gettext_noop('Client ID'),
-                                                     'type': 'string',
-                                                     'help_text': gettext_noop('Alternative to username and password. Required for service account authentication'),
-                                                     },
-                                                    {'id': 'client_secret',
-                                                     'label': gettext_noop('Client Secret'),
-                                                     'type': 'string',
-                                                     'secret': True,
-                                                     'help_text': gettext_noop('Alternative to username and password. Required for service account authentication'),
-                                                     },
-                                                    ],
-                                         'required': [],
-                                         },
-                                 injectors={'extra_vars': {'scm_username': '{{username}}',
-                                                           'scm_password': '{{password}}',
-                                                           'client_id': '{{client_id}}',
-                                                           'client_secret': '{{client_secret}}',
-                                                           'authentication': '{% if client_id %}service_account{% else %}basic{% endif %}',
-                                                           },
-                                            'env': {'INSIGHTS_USER': '{{username}}',
-                                                    'INSIGHTS_PASSWORD': '{{password}}',
-                                                    'INSIGHTS_CLIENT_ID': '{{client_id}}',
-                                                    'INSIGHTS_CLIENT_SECRET': '{{client_secret}}',
-                                                    },
-                                            },
-                                 )
+insights = ManagedCredentialType(
+    namespace='insights',
+    kind='insights',
+    name=gettext_noop('Insights'),
+    managed=True,
+    inputs={
+        'fields': [
+            {
+                'id': 'username',
+                'label': gettext_noop('Username'),
+                'type': 'string',
+                'help_text': gettext_noop(
+                    'Required for basic authentication. '
+                    'May be blank if using client_id and client_secret',
+                ),
+            },
+            {
+                'id': 'password',
+                'label': gettext_noop('Password'),
+                'type': 'string',
+                'secret': True,
+                'help_text': gettext_noop(
+                    'Required for basic authentication. '
+                    'May be blank if using client_id and client_secret',
+                ),
+            },
+            {
+                'id': 'client_id',
+                'label': gettext_noop('Client ID'),
+                'type': 'string',
+                'help_text': gettext_noop(
+                    'Required for service account authentication. '
+                    'May be blank if using username and password',
+                ),
+            },
+            {
+                'id': 'client_secret',
+                'label': gettext_noop('Client Secret'),
+                'type': 'string',
+                'secret': True,
+                'help_text': gettext_noop(
+                    'Required for service account authentication. '
+                    'May be blank if using username and password',
+                ),
+            },
+        ],
+        'required': [],
+    },
+    injectors={
+        'extra_vars': {
+            'scm_username': '{{username}}',
+            'scm_password': '{{password}}',
+            'client_id': '{{client_id}}',
+            'client_secret': '{{client_secret}}',
+            'authentication': '{% if client_id %}service_account{% else %}basic{% endif %}',
+        },
+        'env': {
+            'INSIGHTS_USER': '{{username}}',
+            'INSIGHTS_PASSWORD': '{{password}}',
+            'INSIGHTS_CLIENT_ID': '{{client_id}}',
+            'INSIGHTS_CLIENT_SECRET': '{{client_secret}}',
+        },
+    },
+)
 
 rhv = ManagedCredentialType(
     namespace='rhv',

--- a/src/awx_plugins/credentials/plugins.py
+++ b/src/awx_plugins/credentials/plugins.py
@@ -592,13 +592,13 @@ insights = ManagedCredentialType(
                 'id': 'password', 'label': gettext_noop('Password'), 'type': 'string', 'secret': True,
             },
             {
-                'id': 'client_id', 'label': gettext_noop('Client_ID'), 'type': 'string',
+                'id': 'client_id', 'label': gettext_noop('Client ID'), 'type': 'string',
             },
             {
-                'id': 'client_secret', 'label': gettext_noop('Client_Secret'), 'type': 'string', 'secret': True,
+                'id': 'client_secret', 'label': gettext_noop('Client Secret'), 'type': 'string', 'secret': True,
             }
         ],
-        'required': ['username', 'password'],
+        'required': [],
     },
     injectors={
         'extra_vars': {


### PR DESCRIPTION
Adds `client_id` and `client_secret` fields to the existing insights credential so that users can authenticate with a service account instead of basic auth

so users should either use username/password, or client_id/client_secret

if client_id is set, then authentication method is set to "service_account" automatically