### PR TITLE
Pass authentication field to insights plugin

### DIFF
--- a/src/awx_plugins/inventory/plugins.py
+++ b/src/awx_plugins/inventory/plugins.py
@@ -459,7 +459,6 @@ class insights_supported(PluginFileInjector):
         return inventory_data
 
 
-
 class openshift_virtualization(PluginFileInjector):
     plugin_name = 'kubevirt'
     plugin_description = 'OpenShift Virtualization'

--- a/src/awx_plugins/inventory/plugins.py
+++ b/src/awx_plugins/inventory/plugins.py
@@ -433,6 +433,14 @@ class insights(PluginFileInjector):
     collection = 'insights'
     use_fqcn = True
 
+    def inventory_as_dict(self, inventory_update, private_data_dir):
+        inventory_data = super().inventory_as_dict(inventory_update, private_data_dir)
+        credential = inventory_update.get_cloud_credential()
+        if credential.get_input('client_id', default=''):
+            inventory_data['authentication'] = 'service_account'
+
+        return inventory_data
+
 
 class insights_supported(PluginFileInjector):
     plugin_name = 'insights'
@@ -441,6 +449,15 @@ class insights_supported(PluginFileInjector):
     namespace = 'redhat'
     collection = 'insights'
     use_fqcn = True
+
+    def inventory_as_dict(self, inventory_update, private_data_dir):
+        inventory_data = super().inventory_as_dict(inventory_update, private_data_dir)
+        credential = inventory_update.get_cloud_credential()
+        if credential.get_input('client_id', default=''):
+            inventory_data['authentication'] = 'service_account'
+
+        return inventory_data
+
 
 
 class openshift_virtualization(PluginFileInjector):


### PR DESCRIPTION
This patch will add

`authentication: service_account`

to insights.yml if client_id is defined on the credential.

Even though extra_vars is configured in the insights credential field, extra_vars is not utilized for inventory source syncs.

As such, we can override the inventory_as_dict class on the Inventory plugin to inject "authentication: service_account" param into the insights.yml file.

in the inventory sync private data dir

**inventory/insights.yml**

```
authentication: service_account
plugin: redhatinsights.insights.insights
```

the INSIGHTS_CLIENT_ID and INSIGHTS_CLIENT_SECRET are passed in via environment variables, which is supported by the insights module https://github.com/RedHatInsights/ansible-collections-insights/blob/43e169d6eb0a01d40b3a8df05070e372cb6fd862/docs/inventory.md

