### PR TITLE
💅 Make `CredentialPlugin` named tuple typed

### DIFF
--- a/src/awx_plugins/credentials/plugin.py
+++ b/src/awx_plugins/credentials/plugin.py
@@ -1,19 +1,19 @@
 # FIXME: the following violations must be addressed gradually and unignored
-# mypy: disable-error-code="assignment, no-untyped-def"
+# mypy: disable-error-code="no-untyped-def"
 
 import os
 import tempfile
 import typing
-from collections import namedtuple
 
 from requests.exceptions import HTTPError
 
 
-CredentialPlugin = namedtuple(
-    'CredentialPlugin', [
-        'name', 'inputs', 'backend',
-    ],
-)
+class CredentialPlugin(typing.NamedTuple):
+    """Schema for credential plugins."""
+
+    name: str
+    inputs: object
+    backend: object
 
 
 def raise_for_status(resp):


### PR DESCRIPTION
Previously, it did not specify the schema for `CredentialPlugin`. This caused MyPy to assume `Any` where it was being used.

Now, the structure remains the same but it specifies basic typing information. It can be iterated on further in the future.