### PR TITLE
🚑 Temporarily suppress `codecov-cli` crash

### DIFF
--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -387,8 +387,9 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         disable_search: true
-        fail_ci_if_error: >-
-          ${{ toJSON(inputs.upstream-repository-id == github.repository_id) }}
+        # fail_ci_if_error: >-
+        #   ${{ toJSON(inputs.upstream-repository-id == github.repository_id) }}
+        fail_ci_if_error: false  # TODO: revert once Codecov fixes the error
         files: >-
           ${{ steps.tox-run.outputs.cov-report-files }}
         flags: >-
@@ -411,8 +412,9 @@ jobs:
       uses: codecov/test-results-action@v1
       with:
         disable_search: true
-        fail_ci_if_error: >-
-          ${{ toJSON(inputs.upstream-repository-id == github.repository_id) }}
+        # fail_ci_if_error: >-
+        #   ${{ toJSON(inputs.upstream-repository-id == github.repository_id) }}
+        fail_ci_if_error: false  # TODO: revert once Codecov fixes the error
         files: >-
           ${{ steps.tox-run.outputs.test-result-files }}
         flags: >-


### PR DESCRIPTION
This is an upstream bug that is being fixed. This patch will have to be reverted.

Refs:
* https://github.com/codecov/codecov-cli/issues/641
* https://github.com/codecov/codecov-cli/pull/643