### PR TITLE
🧪 Plug a reusable action for cache mgmt

### DIFF
--- a/.github/actions/cache-keys/action.yml
+++ b/.github/actions/cache-keys/action.yml
@@ -1,0 +1,45 @@
+---
+
+outputs:
+  cache-key-for-dep-files:
+    description: >-
+      A cache key string derived from the dependency declaration files.
+    value: ${{ steps.calc-cache-key-files.outputs.files-hash-key }}
+
+runs:
+  using: composite
+  steps:
+  - name: >-
+      Calculate dependency files' combined hash value
+      for use in the cache key
+    id: calc-cache-key-files
+    run: |
+      from os import environ
+      from pathlib import Path
+
+      FILE_APPEND_MODE = 'a'
+
+      files_derived_hash = '${{
+          hashFiles(
+            'tox.ini',
+            'pyproject.toml',
+            '.pre-commit-config.yaml',
+            'pytest.ini',
+            'dependencies/**',
+            'dependencies/*/**',
+            'setup.cfg'
+          )
+      }}'
+
+      print(f'Computed file-derived hash is {files_derived_hash}.')
+
+      with Path(environ['GITHUB_OUTPUT']).open(
+              mode=FILE_APPEND_MODE,
+      ) as outputs_file:
+          print(
+              f'files-hash-key={files_derived_hash}',
+              file=outputs_file,
+          )
+    shell: python
+
+...

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -152,8 +152,8 @@ jobs:
           )
           && true || false
         }}
-      cache-key-files: >-
-        ${{ steps.calc-cache-key-files.outputs.files-hash-key }}
+      cache-key-for-dep-files: >-
+        ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
       git-tag: ${{ steps.git-tag.outputs.tag }}
       sdist-artifact-name: ${{ steps.artifact-name.outputs.sdist }}
       wheel-artifact-name: ${{ steps.artifact-name.outputs.wheel }}
@@ -199,82 +199,27 @@ jobs:
         ) as outputs_file:
             print('release-requested=true', file=outputs_file)
     - name: Check out src from Git
-      if: >-
-        steps.request-check.outputs.release-requested != 'true'
       uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        fetch-depth: >-
+          ${{
+              steps.request-check.outputs.release-requested == 'true'
+              && 1
+              || 0
+          }}
         ref: ${{ github.event.inputs.release-committish }}
-    - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      if: >-
-        steps.request-check.outputs.release-requested != 'true'
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
     - name: >-
         Calculate dependency files' combined hash value
         for use in the cache key
-      if: >-
-        steps.request-check.outputs.release-requested != 'true'
       id: calc-cache-key-files
-      run: |
-        from os import environ
-        from pathlib import Path
-
-        FILE_APPEND_MODE = 'a'
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(
-                "files-hash-key=${{
-                    hashFiles(
-                      'tox.ini',
-                      'pyproject.toml',
-                      '.pre-commit-config.yaml',
-                      'pytest.ini',
-                      'dependencies/**/*'
-                    )
-                }}",
-                file=outputs_file,
-            )
-    - name: Get pip cache dir
-      id: pip-cache-dir
-      if: >-
-        steps.request-check.outputs.release-requested != 'true'
-      run: >-
-        echo "dir=$(python -m pip cache dir)" >> "${GITHUB_OUTPUT}"
-      shell: bash
+      uses: ./.github/actions/cache-keys
     - name: Set up pip cache
       if: >-
         steps.request-check.outputs.release-requested != 'true'
-      uses: actions/cache@v4
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: ${{ steps.pip-cache-dir.outputs.dir }}
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          steps.calc-cache-key-files.outputs.files-hash-key }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{
-              steps.calc-cache-key-py.outputs.py-hash-key
-          }}-
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+        cache-key-for-dependency-files: >-
+          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
     - name: Drop Git tags from HEAD for non-release requests
       if: >-
         steps.request-check.outputs.release-requested != 'true'
@@ -411,42 +356,11 @@ jobs:
           }}
         ref: ${{ github.event.inputs.release-committish }}
 
-    - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
-      shell: python
-    - name: Get pip cache dir
-      id: pip-cache-dir
-      run: >-
-        echo "dir=$(python -m pip cache dir)" >> "${GITHUB_OUTPUT}"
     - name: Set up pip cache
-      uses: actions/cache@v4
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: ${{ steps.pip-cache-dir.outputs.dir }}
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          needs.pre-setup.outputs.cache-key-files }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{
-              steps.calc-cache-key-py.outputs.py-hash-key
-          }}-
-          ${{ runner.os }}-pip-
+        cache-key-for-dependency-files: >-
+          ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
 
     - name: Identify tox's own lock file
       id: tox-deps
@@ -616,8 +530,8 @@ jobs:
       fail-fast: false
     uses: ./.github/workflows/reusable-tox.yml
     with:
-      cache-key-files: >-
-        ${{ needs.pre-setup.outputs.cache-key-files }}
+      cache-key-for-dependency-files: >-
+        ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
       check-name: >-
         ${{ matrix.check-name }}
       dists-artifact-name: >-
@@ -674,8 +588,8 @@ jobs:
     with:
       built-wheel-names: >-
         ${{ needs.pre-setup.outputs.wheel-artifact-name }}
-      cache-key-files: >-
-        ${{ needs.pre-setup.outputs.cache-key-files }}
+      cache-key-for-dependency-files: >-
+        ${{ needs.pre-setup.outputs.cache-key-for-dep-files }}
       dists-artifact-name: >-
         ${{ needs.pre-setup.outputs.dists-artifact-name }}
       python-version: >-

--- a/.github/workflows/pip-tools.yml
+++ b/.github/workflows/pip-tools.yml
@@ -139,9 +139,18 @@ jobs:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        cache: pip
-        cache-dependency-path: dependencies/**
         python-version: ${{ matrix.python-version }}
+
+    - name: >-
+        Calculate dependency files' combined hash value
+        for use in the cache key
+      id: calc-cache-key-files
+      uses: ./.github/actions/cache-keys
+    - name: Set up pip cache
+      uses: re-actors/cache-python-deps@release/v1
+      with:
+        cache-key-for-dependency-files: >-
+          ${{ steps.calc-cache-key-files.outputs.cache-key-for-dep-files }}
 
     - name: Identify tox's own lock file
       id: tox-deps

--- a/.github/workflows/reusable-tox.yml
+++ b/.github/workflows/reusable-tox.yml
@@ -14,8 +14,8 @@ on:
           to test (is installed into tox env if passed)
         required: false
         type: string
-      cache-key-files:
-        description: Dependency files cache
+      cache-key-for-dependency-files:
+        description: Dependency files hash for use in cache keys
         required: true
         type: string
       check-name:
@@ -185,66 +185,11 @@ jobs:
             hashFiles('.pre-commit-config.yaml')
           }}
 
-    - name: Figure out if the interpreter ABI is stable
-      id: py-abi
-      run: |
-        from os import environ
-        from pathlib import Path
-        from sys import version_info
-
-        FILE_APPEND_MODE = 'a'
-
-        is_stable_abi = version_info.releaselevel == 'final'
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(
-                'is-stable-abi={is_stable_abi}'.
-                format(is_stable_abi=str(is_stable_abi).lower()),
-                file=outputs_file,
-            )
-      shell: python
-    - name: >-
-        Calculate Python interpreter version hash value
-        for use in the cache key
-      if: fromJSON(steps.py-abi.outputs.is-stable-abi)
-      id: calc-cache-key-py
-      run: |
-        from hashlib import sha512
-        from os import environ
-        from pathlib import Path
-        from sys import version
-
-        FILE_APPEND_MODE = 'a'
-
-        hash = sha512(version.encode()).hexdigest()
-
-        with Path(environ['GITHUB_OUTPUT']).open(
-                mode=FILE_APPEND_MODE,
-        ) as outputs_file:
-            print(f'py-hash-key={hash}', file=outputs_file)
-      shell: python
-    - name: Get pip cache dir
-      if: fromJSON(steps.py-abi.outputs.is-stable-abi)
-      id: pip-cache-dir
-      run: >-
-        echo "dir=$(python -Im pip cache dir)" >> "${GITHUB_OUTPUT}"
-      shell: bash
     - name: Set up pip cache
-      if: fromJSON(steps.py-abi.outputs.is-stable-abi)
-      uses: actions/cache@v4
+      uses: re-actors/cache-python-deps@release/v1
       with:
-        path: ${{ steps.pip-cache-dir.outputs.dir }}
-        key: >-
-          ${{ runner.os }}-pip-${{
-          steps.calc-cache-key-py.outputs.py-hash-key }}-${{
-          inputs.cache-key-files }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{
-              steps.calc-cache-key-py.outputs.py-hash-key
-          }}-
-          ${{ runner.os }}-pip-
+        cache-key-for-dependency-files: >-
+          ${{ inputs.cache-key-for-dependency-files }}
 
     - name: Identify tox's own lock file
       id: tox-deps


### PR DESCRIPTION
This action generalizes a piece of code for ABI-sensitive cache management that we were copying around. It also handles corner cases better than `actions/setup-python`.

Refs:
* https://github.com/marketplace/actions/cache-python-deps
* https://github.com/re-actors/cache-python-deps
* https://github.com/aio-libs/frozenlist/pull/622
* https://github.com/aio-libs/frozenlist/pull/633
* https://github.com/actions/setup-python/issues/1034
* https://github.com/cherrypy/cheroot/pull/739