### PR TITLE
Make possible to require 100% coverage of the `tests/` directory

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,7 @@ coverage:
       default:
         target: 100%
       pytest:
-        target: 50%
+        target: 100%
         flags:
         - pytest
       typing:

--- a/nitpick-style.toml
+++ b/nitpick-style.toml
@@ -158,7 +158,7 @@ target = '100%'
 flags = [
   'pytest',
 ]
-target = '50%'
+target = '100%'
 [".codecov.yml".coverage.status.patch.typing]
 flags = [
   'MyPy',

--- a/tests/managed_credential_plugins_test.py
+++ b/tests/managed_credential_plugins_test.py
@@ -10,7 +10,7 @@ from collections.abc import Generator
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import Generic, TypeVar
+from typing import Generic, Never, TypeVar
 
 import pytest
 
@@ -141,7 +141,7 @@ class BaseEnvFile(Generic[ExpectedDataType]):
         self: 'BaseEnvFile[ExpectedDataType]',
         env: EnvVarsType,
         private_data_dir: str,
-    ) -> None:
+    ) -> None | Never:
         """Override to ensure file contains expected data.
 
         :param env: environment to get the filename from

--- a/tests/managed_credential_plugins_test.py
+++ b/tests/managed_credential_plugins_test.py
@@ -8,7 +8,6 @@ import shutil
 import tempfile
 from collections.abc import Generator
 from dataclasses import dataclass
-from pathlib import Path
 from types import MappingProxyType
 from typing import Generic, Never, TypeVar
 
@@ -95,20 +94,8 @@ def to_host_path(path: str, private_data_dir: str) -> str:
 
     :param path: container path
     :param private_data_dir: runtime directory
-    :raises ValueError: When private_data_dir is not an absolute path
-    :raises ValueError: path must be a subdir of the container root dir
     :return: Absolute path of private_data_dir on the container host
     """
-    if not os.path.isabs(private_data_dir):
-        raise ValueError('The private_data_dir path must be absolute')
-    is_subdir_of_container = (
-        CONTAINER_ROOT == path
-        or Path(CONTAINER_ROOT) in Path(path).resolve().parents
-    )
-    if not is_subdir_of_container:
-        raise ValueError(
-            f'Cannot convert path {path}, not a subdir of {CONTAINER_ROOT}',
-        )
     return path.replace(CONTAINER_ROOT, private_data_dir, 1)
 
 

--- a/tests/managed_credential_plugins_test.py
+++ b/tests/managed_credential_plugins_test.py
@@ -148,7 +148,7 @@ class BaseEnvFile(Generic[ExpectedDataType]):
         :param private_data_dir: directory to read the file from
         :returns: None
         """
-        raise RuntimeError('Define me.')
+        raise NotImplementedError('Define me.')
 
 
 class JsonEnvFile(BaseEnvFile[dict[str, str] | MappingProxyType[str, str]]):


### PR DESCRIPTION
This patch deletes dead code in tests and marks the overrideable line as unmeasured in coveragepy. It additionally recovers the expectation that PR diffs are to be fully covered.