### PR TITLE
Add in Cache-Control headers with CyberArk Credential Providers

### DIFF
--- a/src/awx_plugins/credentials/aim.py
+++ b/src/awx_plugins/credentials/aim.py
@@ -102,9 +102,9 @@ def aim_backend(**kwargs):
 
     request_qs = '?' + urlencode(query_params, quote_via=quote)
     request_url = urljoin(url, '/'.join([webservice_id, 'api', 'Accounts']))
-    
+
     headers = {
-        'Cache-Control': 'no-cache'
+        'Cache-Control': 'no-cache',
     }
 
     with CertFiles(client_cert, client_key) as cert:
@@ -114,7 +114,7 @@ def aim_backend(**kwargs):
             cert=cert,
             verify=verify,
             allow_redirects=False,
-            headers=headers
+            headers=headers,
         )
     sensitive_query_params = {
         'AppId': '****',

--- a/src/awx_plugins/credentials/aim.py
+++ b/src/awx_plugins/credentials/aim.py
@@ -102,6 +102,10 @@ def aim_backend(**kwargs):
 
     request_qs = '?' + urlencode(query_params, quote_via=quote)
     request_url = urljoin(url, '/'.join([webservice_id, 'api', 'Accounts']))
+    
+    headers = {
+        'Cache-Control': 'no-cache'
+    }
 
     with CertFiles(client_cert, client_key) as cert:
         res = requests.get(
@@ -110,6 +114,7 @@ def aim_backend(**kwargs):
             cert=cert,
             verify=verify,
             allow_redirects=False,
+            headers=headers
         )
     sensitive_query_params = {
         'AppId': '****',

--- a/src/awx_plugins/credentials/conjur.py
+++ b/src/awx_plugins/credentials/conjur.py
@@ -140,6 +140,7 @@ def conjur_backend(**kwargs):
                     token.encode('utf-8'),
                 ).decode('utf-8'),
             ),
+            'Cache-Control': 'no-cache',
         },
         'allow_redirects': False,
     }


### PR DESCRIPTION
We've been noticing a lot lately that when we request credentials through these plugins that the password almost always pulls an older password, after forcing a cache-less approach in our CyberArk servers we were finally able to get current passwords. However, running in an enterprise environment, we can't have caching disabled indefinitely.

I searched long for any way to add in headers to the UI to handle this but that bore no fruit. Hoping this gets reviewed and deployed timely to correct my issues.

Thank you for your consideration.