### PR TITLE
Add plugin for Azure VM managed identity

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,11 @@ from importlib.metadata import version as _retrieve_metadata_version_for
 from pathlib import Path
 from tomllib import loads as _parse_toml
 
+from docutils.nodes import literal, reference
+from sphinx.addnodes import pending_xref
+from sphinx.application import Sphinx
+from sphinx.environment import BuildEnvironment
+
 
 # -- Path setup --------------------------------------------------------------
 
@@ -226,3 +231,42 @@ nitpick_ignore = [
     ),
     ('py:class', 'EnvVarsType'),
 ]
+
+
+def _replace_missing_tokencredential_reference(
+    app: Sphinx,
+    env: BuildEnvironment,
+    node: pending_xref,
+    contnode: literal,
+) -> reference | None:
+    if (node.get('refdomain'), node.get('reftype')) != ('py', 'class'):
+        return None
+
+    ref_target = node.get('reftarget', '')
+    if ref_target != 'azure.core.credentials.TokenCredential':
+        return None
+
+    return reference(
+        ref_target,
+        ref_target,
+        internal=False,
+        refuri='https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/core/azure-core/azure/core/credentials.py',
+    )
+
+
+def setup(app: Sphinx) -> dict[str, bool | str]:
+    """Register project-local Sphinx extension-API customizations.
+
+    :param app: Initialized Sphinx app instance.
+    :returns: Extension metadata.
+    """
+    app.connect(
+        'missing-reference',
+        _replace_missing_tokencredential_reference,
+    )
+
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+        'version': release,
+    }

--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -1,5 +1,5 @@
 # FIXME: the following violations must be addressed gradually and unignored
-# mypy: disable-error-code="import-untyped, no-untyped-def"
+# mypy: disable-error-code="no-untyped-def"
 
 from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
     gettext_noop as _,
@@ -7,7 +7,10 @@ from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS4
 
 from azure.identity import ClientSecretCredential
 from azure.keyvault.secrets import SecretClient
-from msrestazure import azure_cloud
+# NOTE: `msrestazure` is deprecated and does not provide usable typing.
+# NOTE: This suppression should be replaced by in-tree type stubs.
+# NOTE: Alternatively, the dependency can be replaced.
+from msrestazure import azure_cloud  # type: ignore[import-untyped]
 
 from .plugin import CredentialPlugin
 

--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -1,12 +1,31 @@
-# FIXME: the following violations must be addressed gradually and unignored
-# mypy: disable-error-code="no-untyped-def"
+"""Microsoft Azure Key Vault Lookup Plugin.
+
+This module defines a credential lookup plugin to authenticate and retrieve
+secrets from an Azure Key Vault. If the Client ID, Tenant ID, and Client
+Secret are provided it will create a credential with those. If one is missing,
+it will attempt to use the Managed Identity of an Azure VM to create a
+credential.
+
+Functions:
+
+- :func:`azure_keyvault_backend`: Creates a credential either with the fields
+  provided or via the VM environment, and retrieves the secret from the Key
+  Vault.
+- ``azure_keyvault_plugin``: Defines the credential plugin interface.
+"""
 
 from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
     gettext_noop as _,
 )
 
-from azure.identity import ClientSecretCredential
+from azure.core.credentials import TokenCredential
+from azure.identity import (
+    ClientSecretCredential,
+    CredentialUnavailableError,
+    ManagedIdentityCredential,
+)
 from azure.keyvault.secrets import SecretClient
+
 # NOTE: `msrestazure` is deprecated and does not provide usable typing.
 # NOTE: This suppression should be replaced by in-tree type stubs.
 # NOTE: Alternatively, the dependency can be replaced.
@@ -75,25 +94,69 @@ azure_keyvault_inputs = {
     ],
     'required': [
         'url',
-        'client',
-        'secret',
-        'tenant',
         'secret_field',
     ],
 }
 
 
-def azure_keyvault_backend(**kwargs):
-    csc = ClientSecretCredential(
-        tenant_id=kwargs['tenant'],
-        client_id=kwargs['client'],
-        client_secret=kwargs['secret'],
-    )
-    kv = SecretClient(credential=csc, vault_url=kwargs['url'])
-    return kv.get_secret(
-        name=kwargs['secret_field'],
-        version=kwargs.get('secret_version', ''),
-    ).value
+def _initialize_credential(
+    tenant: str = '',
+    client: str = '',
+    secret: str = '',
+) -> TokenCredential:
+    explicit_credentials_provided = all((tenant, client, secret))
+
+    if explicit_credentials_provided:
+        return ClientSecretCredential(
+            tenant_id=tenant,
+            client_id=client,
+            client_secret=secret,
+        )
+
+    return ManagedIdentityCredential()
+
+
+# WPS211 "too many args" is controlled externally
+# pylint: disable-next=too-many-arguments,too-many-positional-arguments
+def azure_keyvault_backend(  # noqa: WPS211
+    *,
+    url: str,
+    client: str,
+    secret: str,
+    tenant: str,
+    secret_field: str,
+    secret_version: str,
+) -> str | None:
+    """Get a credential and retrieve a secret from an Azure Key Vault.
+
+    An empty string for an optional parameter counts as not provided.
+
+    :param url: An Azure Key Vault URI.
+    :param client: The Client ID  (optional).
+    :param secret: The Client Secret  (optional).
+    :param tenant: The Tenant ID  (optional).
+    :param secret_field: The name of the secret to retrieve from the
+        vault.
+    :param secret_version: The version of the secret to retrieve
+        (optional).
+    :returns: The secret from the Key Vault.
+    :raises RuntimeError: If the software is not being run on an Azure
+        VM.
+    """
+    chosen_credential = _initialize_credential(tenant, client, secret)
+    keyvault = SecretClient(credential=chosen_credential, vault_url=url)
+    try:
+        keyvault_secret = keyvault.get_secret(
+            name=secret_field,
+            version=secret_version,
+        )
+    except CredentialUnavailableError as secret_lookup_err:
+        raise RuntimeError(
+            'You are not operating on an Azure VM, so the Managed Identity '
+            'feature is unavailable. Please provide the full Client ID, '
+            'Client Secret, and Tenant ID or run the software on an Azure VM.',
+        ) from secret_lookup_err
+    return keyvault_secret.value
 
 
 azure_keyvault_plugin = CredentialPlugin(

--- a/tests/azure_kv_test.py
+++ b/tests/azure_kv_test.py
@@ -1,0 +1,80 @@
+"""Tests Azure Key Vault credential plugin."""
+
+import pytest
+
+from azure.keyvault.secrets import (
+    KeyVaultSecret,
+    SecretClient,
+    SecretProperties,
+)
+
+from awx_plugins.credentials import azure_kv
+
+
+class _FakeSecretClient(SecretClient):
+    def get_secret(
+        self: '_FakeSecretClient',
+        name: str,
+        version: str | None = None,
+        **kwargs: str,
+    ) -> KeyVaultSecret:
+        props = SecretProperties()
+        return KeyVaultSecret(properties=props, value='test-secret')
+
+
+def test_azure_kv_invalid_env() -> None:
+    """Test running outside of Azure raises error."""
+    error_msg = (
+        'You are not operating on an Azure VM, so the Managed Identity '
+        'feature is unavailable. Please provide the full Client ID, '
+        'Client Secret, and Tenant ID or run the software on an Azure VM.'
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=error_msg,
+    ):
+        azure_kv.azure_keyvault_backend(
+            url='https://test.vault.azure.net',
+            client='',
+            secret='client-secret',
+            tenant='tenant-id',
+            secret_field='secret',
+            secret_version='',
+        )
+
+
+@pytest.mark.parametrize(
+    ('client', 'secret', 'tenant'),
+    (
+        pytest.param('', '', '', id='managed-identity'),
+        pytest.param(
+            'client-id',
+            'client-secret',
+            'tenant-id',
+            id='client-secret-credential',
+        ),
+    ),
+)
+def test_azure_kv_valid_auth(
+    monkeypatch: pytest.MonkeyPatch,
+    client: str,
+    secret: str,
+    tenant: str,
+) -> None:
+    """Test successful Azure authentication via Managed Identity and credentials."""
+    monkeypatch.setattr(
+        azure_kv,
+        'SecretClient',
+        _FakeSecretClient,
+    )
+
+    keyvault_secret = azure_kv.azure_keyvault_backend(
+        url='https://test.vault.azure.net',
+        client=client,
+        secret=secret,
+        tenant=tenant,
+        secret_field='secret',
+        secret_version='',
+    )
+    assert keyvault_secret == 'test-secret'


### PR DESCRIPTION
This PR adds a plugin that uses Managed Identities for Azure resources on an Azure VM to authenticate and retrieve secrets from an Azure Key Vault. This is similar to how the existing Azure Key Vault plugin works but it does not require Client ID, Client Secret, or Tenant ID. When run in an Azure VM the identity of the VM will be picked up and used as the credential to authenticate to the Key Vault. The only requirements then are the Vault URL, the name of the secret to retrieve, optionally the version of the secret to retrieve, and for the VM itself to be given the correct Key Vault Administrator role.