### PR TITLE
🧪 Add Ruff linter to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,38 +37,13 @@ repos:
   hooks:
   - id: add-trailing-comma
 
-- repo: https://github.com/asottile/pyupgrade.git
-  rev: v3.19.1
+- repo: https://github.com/astral-sh/ruff-pre-commit.git
+  rev: v0.11.6
   hooks:
-  - id: pyupgrade
+  - id: ruff
     args:
-    - --py311-plus
-
-- repo: https://github.com/PyCQA/isort.git
-  rev: 5.13.2
-  hooks:
-  - id: isort
-    args:
-    - --honor-noqa
-
-- repo: local
-  hooks:
-  - id: docformatter
-    name: docformatter
-    description: Formats docstrings to follow PEP 257.
-    entry: python -Im docformatter
-    additional_dependencies:
-    - docformatter == 1.7.5
-    args:
-    - --in-place
-    language: python
-    types:
-    - python
-
-- repo: https://github.com/hhatto/autopep8.git
-  rev: v2.3.1
-  hooks:
-  - id: autopep8
+    # Ref: https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    - --fix  # NOTE: When `--fix` is used, linting should be before ruff-format
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks.git
   rev: v1.5.5
@@ -185,7 +160,7 @@ repos:
     - flake8-logging ~= 1.6.0
     - flake8-logging-format ~= 2024.24.12
     - flake8-pytest-style ~= 2.0.0
-    - wemake-python-styleguide ~= 0.19.2
+    - wemake-python-styleguide ~= 1.1.0
     language_version: python3
 
 - repo: https://github.com/pre-commit/mirrors-mypy.git

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,302 @@
+line-length = 79  # Accessibility-friendly
+
+namespace-packages = [
+  "bin/",
+  "docs/",
+  "src/awx_plugins/",
+  "tests/",
+]
+
+[lint]
+ignore = [
+  "CPY001",  # Skip copyright notice requirement at top of files
+
+  # Legitimate cases, no need to "fix" these violations:
+  # E501: "line too long", its function is replaced by `flake8-length`
+  "E501",
+  # W505: "doc line too long", its function is replaced by `flake8-length`
+  "W505",
+
+  "A001",  # builtin-variable-shadowing  # FIXME / noqa
+
+  "ARG001",  # unused-function-argument  # FIXME / noqa
+  "ARG002",  # unused-method-argument  # FIXME / noqa
+
+  "B904",  # raise-without-from-inside-except  # FIXME
+
+  "BLE001",  # blind-except  # FIXME
+
+  "FURB101",  # read-whole-file  # FIXME
+
+  # Refs:
+  # * https://github.com/astral-sh/ruff/issues/6606
+  # * https://github.com/astral-sh/ruff/pull/13286
+  "DOC201",  # Ruff doesn't understand sphinx-native param lists
+  "DOC501",  # docstring-missing-exception  # Ruff doesn't understand sphinx-native param lists
+
+  "FIX002",  # line-contains-todo  # FIXME / noqa
+
+  "FLY002",  # static-join-to-f-string  # FIXME
+
+  "EM101",  # raw-string-in-exception  # FIXME
+  "EM102",  # f-string-in-exception  # FIXME
+
+  # Ref: https://github.com/astral-sh/ruff/issues/4845#issuecomment-2816845547
+  "ERA001",  # False-positives in commented-out code
+
+  "FIX001",  # line-contains-fixme  # FIXME
+
+  "PLC0414",  # useless-import-alias  # needed for MyPy explicit re-exports
+  "PLC0415",  # import-outside-top-level  # FIXME
+  "PLC1901",  # compare-to-empty-string  # FIXME
+
+  "PLR0912",  # too-many-branches  # FIXME
+  "PLR0913",  # too-many-arguments  # FIXME / noqa
+  "PLR0914",  # too-many-locals  # FIXME / noqa
+  "PLR0917",  # too-many-positional-arguments  # FIXME / noqa
+  "PLR2004",  # magic-value-comparison  # FIXME
+  "PLR6301",  # no-self-use  # FIXME / noqa
+
+  "PLW1514",  # unspecified-encoding  # FIXME
+
+  "PTH101",  # os-chmod  # FIXME
+  "PTH107",  # os-remove  # FIXME
+  "PTH110",  # os-path-exists  # FIXME
+  "PTH118",  # os-path-join  # FIXME
+  "PTH123",  # builtin-open  # FIXME
+
+  "RET504",  # unnecessary-assign  # FIXME
+
+  "S105",  # hardcoded-password-string  # FIXME
+  "S113",  # request-without-timeout  # FIXME
+
+  "SIM117",  # multiple-with-statements  # FIXME
+
+  "T201",  # print  # FIXME
+
+  "TD001",   # invalid-todo-tag  # FIXME
+  "TD002",   # missing-todo-author  # FIXME
+  "TD003",   # missing-todo-link  # FIXME
+  "TD004",   # missing-todo-colon  # FIXME
+  "TD005",   # missing-todo-description  # FIXME
+
+
+  "TRY002",  # raise-vanilla-class  # FIXME
+  "TRY003",  # raise-vanilla-args  # controversial
+  "TRY201",  # verbose-raise  # FIXME
+  "TRY203",  # useless-try-except  # FIXME
+
+  "RUF005",  # collection-literal-concatenation  # FIXME
+  "RUF100",  # Ruff doesn't know about WPS
+  "RUF102",  # Ruff doesn't know about WPS
+]
+preview = true  # Live dangerously
+select = [
+  "ALL",
+]
+task-tags = [
+  "FIXME",
+  "NOTE",
+  "Ref",
+  "Refs",
+  "TODO",
+]
+
+[lint.flake8-pytest-style]
+parametrize-values-type = "tuple"
+
+[lint.flake8-quotes]
+inline-quotes = "single"
+
+[lint.isort]
+combine-as-imports = true
+force-wrap-aliases = true
+lines-after-imports = 2
+section-order = [
+  "future",
+  "standard-library",
+  "testing",
+  "frameworks",
+  "platforms",
+  "third-party",
+  "first-party",
+  "local-folder",
+]
+
+[lint.isort.sections]
+frameworks = [
+  "awx",
+  "django",
+]
+platforms = [
+  "awx_plugins.interfaces",
+]
+testing = [
+  "hypothesis",
+  "pytest",
+  "pytest_mock",
+  "pytest_subtests",
+]
+
+[lint.per-file-ignores]
+"tests/**.py" = [
+  # The following ignores have been researched and should be considered permanent
+  # each should be preceded with an explanation of each of the error codes
+  # If other ignores are added for a specific file in the section following this,
+  # these will need to be added to that line as well.
+
+  "ARG002",  # Allow unused arguments in instance methods (required for test stubs)
+  "PLC2701", # Allow importing internal files needed for testing
+  "PLR6301", # Allow 'self' parameter in method definitions (required for test stubs)
+  "S101",    # Allow use of `assert` in test files
+  "S105",    # hardcoded-password-string
+  "S108",    # tmp dirs
+  "S404",    # Allow importing 'subprocess' module to testing call external tools needed by these hooks
+  "S603",    # subprocess calls
+  "SLF001",  # Private member accessed
+]
+
+"src/awx_plugins/credentials/aim.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN003",
+  "ANN201",
+  "D100",
+  "D103",
+  "Q003",
+]
+
+"src/awx_plugins/credentials/aws_secretsmanager.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN003",
+  "ANN201",
+  "D100",
+  "D103",
+]
+
+"src/awx_plugins/credentials/azure_kv.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN003",
+  "ANN201",
+  "D100",
+  "D103",
+]
+
+"src/awx_plugins/credentials/centrify_vault.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN003",
+  "ANN201",
+  "D100",
+  "D103",
+  "N802",
+]
+
+"src/awx_plugins/credentials/conjur.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN003",
+  "ANN201",
+  "D100",
+  "D103",
+]
+
+"src/awx_plugins/credentials/dsv.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN003",
+  "ANN201",
+  "D100",
+  "D103",
+]
+
+"src/awx_plugins/credentials/github_app.py" = [
+  "S101",  # `assert` used for type narrowing
+]
+
+"src/awx_plugins/credentials/hashivault.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN003",
+  "ANN201",
+  "C901",
+  "D100",
+  "D103",
+]
+
+
+"src/awx_plugins/credentials/injectors.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN201",
+  "ANN202",
+  "C408",
+  "D100",
+  "D103",
+]
+
+"src/awx_plugins/credentials/plugin.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN001",
+  "ANN002",
+  "ANN201",
+  "ANN204",
+  "B010",
+  "D100",
+  "D101",
+  "D103",
+  "D105",
+  "D107",
+  "D205",
+  "D400",
+  "E731",
+]
+
+"src/awx_plugins/credentials/plugins.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "D100",
+  "D101",
+  "D103",
+  "D105",
+  "D107",
+  "D205",
+  "D400",
+]
+
+"src/awx_plugins/credentials/tss.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN003",
+  "ANN201",
+  "ANN202",
+  "D100",
+  "D103",
+  "E712",
+]
+
+"src/awx_plugins/inventory/plugins.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "ANN001",
+  "ANN002",
+  "ANN003",
+  "ANN201",
+  "ANN202",
+  "ANN206",
+  "D100",
+  "D101",
+  "D102",
+  "D205",
+  "D209",
+  "D400",
+  "D401",
+  "N801",
+]
+
+"tests/credential_plugins_test.py" = [
+  # The following ignores must be fixed and the entries removed from this config:
+  "B017",
+  "C419",
+  "D100",
+  "D102",
+  "D103",
+  "D205",
+  "D209",
+  "D400",
+  "PT011",
+]
+
+[lint.pydocstyle]
+convention = "pep257"

--- a/src/awx_plugins/credentials/aim.py
+++ b/src/awx_plugins/credentials/aim.py
@@ -80,15 +80,15 @@ aim_inputs = {
 
 def aim_backend(**kwargs):
     url = kwargs['url']
-    client_cert = kwargs.get('client_cert', None)
-    client_key = kwargs.get('client_key', None)
+    client_cert = kwargs.get('client_cert')
+    client_key = kwargs.get('client_key')
     verify = kwargs['verify']
     webservice_id = kwargs.get('webservice_id', '')
     app_id = kwargs['app_id']
     object_query = kwargs['object_query']
     object_query_format = kwargs['object_query_format']
     object_property = kwargs.get('object_property', '')
-    reason = kwargs.get('reason', None)
+    reason = kwargs.get('reason')
     if webservice_id == '':
         webservice_id = 'AIMWebService'
 
@@ -136,7 +136,7 @@ def aim_backend(**kwargs):
         object_property = 'Content'
     elif object_property.lower() == 'address':
         object_property = 'Address'
-    elif object_property not in res:
+    elif object_property not in res:  # noqa: WPS504  # FIXME
         raise KeyError(
             f'Property {object_property} not found in object, available properties: Username, Password and Address',
         )

--- a/src/awx_plugins/credentials/conjur.py
+++ b/src/awx_plugins/credentials/conjur.py
@@ -96,7 +96,7 @@ def conjur_backend(**kwargs):
     username = quote(kwargs['username'], safe='')
     secret_path = quote(kwargs['secret_path'], safe='')
     version = kwargs.get('secret_version')
-    cacert = kwargs.get('cacert', None)
+    cacert = kwargs.get('cacert')
 
     auth_kwargs = {
         'headers': {'Content-Type': 'text/plain', 'Accept-Encoding': 'base64'},

--- a/src/awx_plugins/credentials/github_app.py
+++ b/src/awx_plugins/credentials/github_app.py
@@ -17,7 +17,10 @@ from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS4
     gettext_noop as _,
 )
 
-from github import Auth as Auth, Github
+from github import (
+    Auth as Auth,
+    Github,
+)
 from github.Consts import DEFAULT_BASE_URL as PUBLIC_GH_API_URL
 from github.GithubException import (
     BadAttributeException,
@@ -214,7 +217,7 @@ def extract_github_app_install_token(  # noqa: WPS210
 
     Github(  # Generate a GitHub App authentication token
         auth=auth,
-        base_url=github_api_url if github_api_url else PUBLIC_GH_API_URL,
+        base_url=github_api_url or PUBLIC_GH_API_URL,
     )
 
     doc_url = (

--- a/src/awx_plugins/credentials/hashivault.py
+++ b/src/awx_plugins/credentials/hashivault.py
@@ -309,7 +309,7 @@ def method_auth(**kwargs):
     auth_path = kwargs.get('auth_path') or kwargs['default_auth_path']
 
     url = urljoin(kwargs['url'], 'v1')
-    cacert = kwargs.get('cacert', None)
+    cacert = kwargs.get('cacert')
 
     sess = requests.Session()
     sess.mount(url, requests.adapters.HTTPAdapter(max_retries=5))
@@ -342,9 +342,9 @@ def kv_backend(**kwargs):
     token = handle_auth(**kwargs)
     url = kwargs['url']
     secret_path = kwargs['secret_path']
-    secret_backend = kwargs.get('secret_backend', None)
-    secret_key = kwargs.get('secret_key', None)
-    cacert = kwargs.get('cacert', None)
+    secret_backend = kwargs.get('secret_backend')
+    secret_key = kwargs.get('secret_key')
+    cacert = kwargs.get('cacert')
     api_version = kwargs['api_version']
 
     request_kwargs = {
@@ -376,11 +376,10 @@ def kv_backend(**kwargs):
                 mount_point, path = secret_path, []
             # https://www.vaultproject.io/api/secret/kv/kv-v2.html#read-secret-version
             path_segments = [mount_point, 'data'] + path
+    elif secret_backend:
+        path_segments = [secret_backend, secret_path]
     else:
-        if secret_backend:
-            path_segments = [secret_backend, secret_path]
-        else:
-            path_segments = [secret_path]
+        path_segments = [secret_path]
 
     request_url = urljoin(url, '/'.join(['v1'] + path_segments)).rstrip('/')
     with CertFiles(cacert) as cert:
@@ -417,7 +416,7 @@ def ssh_backend(**kwargs):
     url = urljoin(kwargs['url'], 'v1')
     secret_path = kwargs['secret_path']
     role = kwargs['role']
-    cacert = kwargs.get('cacert', None)
+    cacert = kwargs.get('cacert')
 
     request_kwargs = {
         'timeout': 30,

--- a/src/awx_plugins/credentials/tss.py
+++ b/src/awx_plugins/credentials/tss.py
@@ -97,8 +97,7 @@ def tss_backend(**kwargs):
 
     if isinstance(secret.fields[kwargs['secret_field']].value, str) == False:
         return secret.fields[kwargs['secret_field']].value.text
-    else:
-        return secret.fields[kwargs['secret_field']].value
+    return secret.fields[kwargs['secret_field']].value
 
 
 tss_plugin = CredentialPlugin(

--- a/src/awx_plugins/inventory/plugins.py
+++ b/src/awx_plugins/inventory/plugins.py
@@ -221,7 +221,8 @@ class openstack(PluginFileInjector):
         openstack_data = _openstack_data(cred)
 
         openstack_data['clouds']['devstack']['private'] = inventory_update.source_vars_dict.get(
-            'private', True, )
+            'private', True,
+        )
         ansible_variables = {
             'use_hostnames': True,
             'expand_hostvars': False,

--- a/tests/managed_credential_plugins_test.py
+++ b/tests/managed_credential_plugins_test.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import Generic, Never, TypeVar
+from typing import Generic, TypeVar
 
 import pytest
 from pytest_subtests import SubTests
@@ -122,7 +122,7 @@ class BaseEnvFile(Generic[ExpectedDataType]):
         self: 'BaseEnvFile[ExpectedDataType]',
         env: EnvVarsType,
         private_data_dir: str,
-    ) -> None | Never:
+    ) -> None:
         """Override to ensure file contains expected data.
 
         :param env: environment to get the filename from


### PR DESCRIPTION
It is integrated with auto-fixing enabled which effectively replaces `pyupgrade`, `isort` and `docformatter`. It does not yet fully [[1]] cover `autopep8`, though.

`autopep8` is being removed since the combination of `add-trailing-comma` and `ruff` works rather well with trailing commas.

And the formatter mode isn't enabled either due to partial incompatibility with `add-trailing-comma`.

The WPS flake8 plugin is upgraded to v1.1.0 as it drops a lot of checks performed by `ruff`. Other plugins are not removed and should be evaluated for being covered by `ruff` in follow-ups.

[1]: https://github.com/astral-sh/ruff/issues/5564#issuecomment-1623901448