### PR TITLE
🧪 Integrate ruff formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -69,3 +69,5 @@
 
 
 6a5f31597a8ffb5b58c1ff956bb7e9da20c77f62  # 💅 Auto-format the initial repository state
+
+02c7d221f588ad89c68f1391c09c8ba17046c9ec  # 💅🤖 Auto-format entire repository with Ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,20 @@ repos:
     - file
     - symlink
 
+- repo: https://github.com/astral-sh/ruff-pre-commit.git
+  rev: v0.11.6
+  hooks:
+  - id: ruff
+    args:
+    # Ref: https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    - --fix  # NOTE: When `--fix` is used, linting should be before ruff-format
+
+- repo: https://github.com/astral-sh/ruff-pre-commit.git
+  rev: v0.11.6
+  hooks:
+  - id: ruff-format
+    alias: ruff-format-first-pass
+
 - repo: https://github.com/asottile/add-trailing-comma.git
   rev: v3.1.0
   hooks:
@@ -40,10 +54,8 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit.git
   rev: v0.11.6
   hooks:
-  - id: ruff
-    args:
-    # Ref: https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
-    - --fix  # NOTE: When `--fix` is used, linting should be before ruff-format
+  - id: ruff-format
+    alias: ruff-format-second-pass
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks.git
   rev: v1.5.5

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -7,6 +7,9 @@ namespace-packages = [
   "tests/",
 ]
 
+[format]
+quote-style = "single"
+
 [lint]
 ignore = [
   "CPY001",  # Skip copyright notice requirement at top of files

--- a/bin/pip_constraint_helpers.py
+++ b/bin/pip_constraint_helpers.py
@@ -35,7 +35,7 @@ def get_runtime_python_tag() -> str:
 
     python_minor_ver_tag = ''.join(map(str, python_minor_ver))
 
-    return f'{python_tag_prefix !s}{python_minor_ver_tag !s}'
+    return f'{python_tag_prefix!s}{python_minor_ver_tag!s}'
 
 
 def get_constraint_file_path(  # noqa: WPS210 -- no way to drop vars
@@ -84,7 +84,7 @@ def make_pip_cmd(
     else:
         print(  # noqa: WPS421
             'WARNING: The expected pinned constraints file for the current '
-            f'env does not exist (should be "{constraint_file_path !s}").',
+            f'env does not exist (should be "{constraint_file_path!s}").',
         )
     return pip_cmd
 
@@ -95,5 +95,5 @@ def run_cmd(cmd: list[str] | tuple[str, ...]) -> None:
     :param cmd: The command to invoke.
     """
     escaped_cmd = shlex.join(cmd)
-    print(f'Invoking the following command: {escaped_cmd !s}')  # noqa: WPS421
+    print(f'Invoking the following command: {escaped_cmd!s}')  # noqa: WPS421
     subprocess.check_call(cmd)  # noqa: S603

--- a/bin/resolve_platform_lock_file.py
+++ b/bin/resolve_platform_lock_file.py
@@ -12,7 +12,9 @@ from pip_constraint_helpers import (
 
 
 def generate_lock_for(
-    req_dir: str, toxenv: str, *pip_compile_extra_args: tuple[str, ...],
+    req_dir: str,
+    toxenv: str,
+    *pip_compile_extra_args: tuple[str, ...],
 ) -> None:
     """Generate a patform-specific lock file for given tox env.
 
@@ -22,16 +24,19 @@ def generate_lock_for(
         compile.
     """
     lock_file_name = get_constraint_file_path(
-        req_dir, toxenv, get_runtime_python_tag(),
+        req_dir,
+        toxenv,
+        get_runtime_python_tag(),
     )
     direct_deps_file_name = (
-        lock_file_name.parents[1]
-        / 'direct'
-        / f'{toxenv}.in'
+        lock_file_name.parents[1] / 'direct' / f'{toxenv}.in'
     )
     pip_compile_cmd = (
-        sys.executable, '-Im', 'piptools', 'compile',
-        f'--output-file={lock_file_name !s}',
+        sys.executable,
+        '-Im',
+        'piptools',
+        'compile',
+        f'--output-file={lock_file_name!s}',
         str(direct_deps_file_name),
         *pip_compile_extra_args,
     )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,7 @@ PROJECT_ROOT_DIR = DOCS_ROOT_DIR.parent.resolve()
 PROJECT_SRC_DIR = PROJECT_ROOT_DIR / 'src'
 IS_RTD_ENV = os.getenv('READTHEDOCS', 'False') == 'True'
 IS_RELEASE_ON_RTD = (
-    IS_RTD_ENV
-    and os.environ['READTHEDOCS_VERSION_TYPE'] == 'tag'
+    IS_RTD_ENV and os.environ['READTHEDOCS_VERSION_TYPE'] == 'tag'
 )
 tags: set[str]
 if IS_RELEASE_ON_RTD:
@@ -46,14 +45,16 @@ copyright = author  # pylint: disable=redefined-builtin
 # The full version, including alpha/beta/rc tags
 release = (
     # pylint: disable-next=used-before-assignment
-    'unversioned' if tags.has('is_unversioned')  # noqa: F821
+    'unversioned'
+    if tags.has('is_unversioned')  # noqa: F821
     else _retrieve_metadata_version_for(project)
 )
 
 # The short X.Y version
 version = (
     # pylint: disable-next=used-before-assignment
-    'unversioned' if tags.has('is_unversioned')  # noqa: F821
+    'unversioned'
+    if tags.has('is_unversioned')  # noqa: F821
     else '.'.join(release.split('.')[:2])
 )
 
@@ -70,7 +71,6 @@ extensions = [
     'sphinx.ext.coverage',  # for invoking with `-b coverage`
     'sphinx.ext.doctest',  # for invoking with `-b doctest`
     'sphinx.ext.intersphinx',
-
     # Third-party extensions:
     'myst_parser',  # extended markdown; https://pypi.org/project/myst-parser/
     'sphinx_autodoc_typehints',  # gets function param types from annotations
@@ -78,7 +78,6 @@ extensions = [
     'sphinx_tabs.tabs',
     'sphinxawesome.codelinter',  # checks code blocks with linters
     'sphinxcontrib.apidoc',
-
     # In-tree extensions:
     'spelling_stub_ext',  # auto-loads `sphinxcontrib.spelling` if installed
 ]

--- a/src/awx_plugins/credentials/aim.py
+++ b/src/awx_plugins/credentials/aim.py
@@ -24,7 +24,9 @@ aim_inputs = {
             'id': 'webservice_id',
             'label': _('Web Service ID'),
             'type': 'string',
-            'help_text': _('The CCP Web Service ID. Leave blank to default to AIMWebService.'),
+            'help_text': _(
+                'The CCP Web Service ID. Leave blank to default to AIMWebService.',
+            ),
         },
         {
             'id': 'app_id',
@@ -58,20 +60,32 @@ aim_inputs = {
             'id': 'object_query',
             'label': _('Object Query'),
             'type': 'string',
-            'help_text': _('Lookup query for the object. Ex: Safe=TestSafe;Object=testAccountName123'),
+            'help_text': _(
+                'Lookup query for the object. Ex: Safe=TestSafe;Object=testAccountName123',
+            ),
         },
-        {'id': 'object_query_format', 'label': _('Object Query Format'), 'type': 'string', 'default': 'Exact', 'choices': ['Exact', 'Regexp']},
+        {
+            'id': 'object_query_format',
+            'label': _('Object Query Format'),
+            'type': 'string',
+            'default': 'Exact',
+            'choices': ['Exact', 'Regexp'],
+        },
         {
             'id': 'object_property',
             'label': _('Object Property'),
             'type': 'string',
-            'help_text': _('The property of the object to return. Available properties: Username, Password and Address.'),
+            'help_text': _(
+                'The property of the object to return. Available properties: Username, Password and Address.',
+            ),
         },
         {
             'id': 'reason',
             'label': _('Reason'),
             'type': 'string',
-            'help_text': _('Object request reason. This is only needed if it is required by the object\'s policy.'),
+            'help_text': _(
+                "Object request reason. This is only needed if it is required by the object's policy.",
+            ),
         },
     ],
     'required': ['url', 'app_id', 'object_query'],

--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -14,7 +14,8 @@ from .plugin import CredentialPlugin
 
 # https://github.com/Azure/msrestazure-for-python/blob/master/msrestazure/azure_cloud.py
 clouds = [
-    vars(azure_cloud)[n] for n in dir(azure_cloud)
+    vars(azure_cloud)[n]
+    for n in dir(azure_cloud)
     if n.startswith('AZURE_') and n.endswith('_CLOUD')
 ]
 default_cloud = vars(azure_cloud)['AZURE_PUBLIC_CLOUD']

--- a/src/awx_plugins/credentials/centrify_vault.py
+++ b/src/awx_plugins/credentials/centrify_vault.py
@@ -123,7 +123,7 @@ def get_ID(**kwargs):
     # FIXME: sanitize input
     query = f'Select ID from VaultAccount where {name}'  # noqa: S608
     post_headers = {
-        'Authorization': 'Bearer ' + kwargs['access_token'],
+        'Authorization': f'Bearer {kwargs["access_token"]}',
         'X-CENTRIFY-NATIVE-CLIENT': 'true',
     }
     response = requests.post(

--- a/src/awx_plugins/credentials/centrify_vault.py
+++ b/src/awx_plugins/credentials/centrify_vault.py
@@ -117,13 +117,13 @@ def handle_auth(**kwargs):
 def get_ID(**kwargs):
     endpoint = urljoin(kwargs['url'], '/Redrock/query')
     name = " Name='{}' and User='{}'".format(
-        kwargs['system_name'], kwargs['acc_name'],
+        kwargs['system_name'],
+        kwargs['acc_name'],
     )
     # FIXME: sanitize input
     query = f'Select ID from VaultAccount where {name}'  # noqa: S608
     post_headers = {
-        'Authorization': 'Bearer ' +
-        kwargs['access_token'],
+        'Authorization': 'Bearer ' + kwargs['access_token'],
         'X-CENTRIFY-NATIVE-CLIENT': 'true',
     }
     response = requests.post(
@@ -150,7 +150,7 @@ def get_ID(**kwargs):
 def get_passwd(**kwargs):
     endpoint = urljoin(kwargs['url'], '/ServerManage/CheckoutPassword')
     post_headers = {
-        'Authorization': f"Bearer {kwargs['access_token'] !s}",
+        'Authorization': f'Bearer {kwargs["access_token"]!s}',
         'X-CENTRIFY-NATIVE-CLIENT': 'true',
     }
     response = requests.post(

--- a/src/awx_plugins/credentials/conjur.py
+++ b/src/awx_plugins/credentials/conjur.py
@@ -110,10 +110,15 @@ def conjur_backend(**kwargs):
         try:
             resp = requests.post(  # noqa: S113; FIXME: add a reasonable timeout
                 urljoin(
-                    url, '/'.join([
-                        'authn', account,
-                        username, 'authenticate',
-                    ]),
+                    url,
+                    '/'.join(
+                        [
+                            'authn',
+                            account,
+                            username,
+                            'authenticate',
+                        ],
+                    ),
                 ),
                 # timeout=1,
                 **auth_kwargs,
@@ -122,10 +127,16 @@ def conjur_backend(**kwargs):
         except requests.exceptions.HTTPError:
             resp = requests.post(  # noqa: S113; FIXME: add a reasonable timeout
                 urljoin(
-                    url, '/'.join([
-                        'api', 'authn', account,
-                        username, 'authenticate',
-                    ]),
+                    url,
+                    '/'.join(
+                        [
+                            'api',
+                            'authn',
+                            account,
+                            username,
+                            'authenticate',
+                        ],
+                    ),
                 ),
                 # timeout=1,
                 **auth_kwargs,
@@ -136,7 +147,9 @@ def conjur_backend(**kwargs):
     lookup_kwargs = {
         'headers': {
             'Authorization': 'Token token="{}"'.format(
-                token if _is_base64(token) else base64.b64encode(
+                token
+                if _is_base64(token)
+                else base64.b64encode(
                     token.encode('utf-8'),
                 ).decode('utf-8'),
             ),
@@ -146,10 +159,12 @@ def conjur_backend(**kwargs):
 
     # https://www.conjur.org/api.html#secrets-retrieve-a-secret-get
     path = urljoin(
-        url, '/'.join(['secrets', account, 'variable', secret_path]),
+        url,
+        '/'.join(['secrets', account, 'variable', secret_path]),
     )
     path_conjurcloud = urljoin(
-        url, '/'.join(['api', 'secrets', account, 'variable', secret_path]),
+        url,
+        '/'.join(['api', 'secrets', account, 'variable', secret_path]),
     )
     if version:
         ver = f'version={version}'

--- a/src/awx_plugins/credentials/dsv.py
+++ b/src/awx_plugins/credentials/dsv.py
@@ -115,7 +115,8 @@ def dsv_backend(**kwargs):
     tenant_name = kwargs['tenant']
     tenant_tld = kwargs.get('tld', 'com')
     tenant_url_template = kwargs.get(
-        'url_template', 'https://{}.secretsvaultcloud.{}',
+        'url_template',
+        'https://{}.secretsvaultcloud.{}',
     )
     client_id = kwargs['client_id']
     client_secret = kwargs['client_secret']

--- a/src/awx_plugins/credentials/github_app.py
+++ b/src/awx_plugins/credentials/github_app.py
@@ -165,26 +165,27 @@ def _is_app_or_client_id(app_or_client_id_candidate: str | int) -> bool:
 
 
 def _assert_ids_look_acceptable(
-    app_or_client_id: int | str, install_id: int | str,
+    app_or_client_id: int | str,
+    install_id: int | str,
 ) -> None:
     if not _is_app_or_client_id(app_or_client_id):
         raise ValueError(
             'Expected GitHub App or Client ID to be an integer or a string '
             f'starting with `Iv1.` followed by 16 hexadecimal digits, '
-            f'but got {app_or_client_id !r}',
+            f'but got {app_or_client_id!r}',
         )
 
     if isinstance(app_or_client_id, str) and _is_client_id(app_or_client_id):
         raise ValueError(
             'Expected GitHub App ID must be an integer or a string '
-            f'with an all-digit value, but got {app_or_client_id !r}. '
+            f'with an all-digit value, but got {app_or_client_id!r}. '
             'Client IDs are currently unsupported.',
         )
 
     if not _is_intish(install_id):
         raise ValueError(
             'Expected GitHub App Installation ID to be an integer'
-            f' but got {install_id !r}',
+            f' but got {install_id!r}',
         )
 
 
@@ -244,22 +245,22 @@ def extract_github_app_install_token(  # noqa: WPS210
     ) as github_install_not_found_exc:
         raise ValueError(
             'Failed to retrieve a GitHub installation token from '
-            f'{github_api_url !s} using {app_install_context !s}. '
-            f'Is the app installed? {doc_url !s}.'
-            f'\n\n{github_install_not_found_exc !s}',
+            f'{github_api_url!s} using {app_install_context!s}. '
+            f'Is the app installed? {doc_url!s}.'
+            f'\n\n{github_install_not_found_exc!s}',
         ) from github_install_not_found_exc
     except GithubException as pygithub_catchall_exc:  # type: ignore[misc]
         raise RuntimeError(
             'An unexpected error happened while talking to GitHub API @ '
-            f'{github_api_url !s} ({app_install_context !s}). '
+            f'{github_api_url!s} ({app_install_context!s}). '
             'Is the app or client ID correct? And the private RSA key? '
-            f'{doc_url !s}.\n\n{pygithub_catchall_exc !s}',
+            f'{doc_url!s}.\n\n{pygithub_catchall_exc!s}',
         ) from pygithub_catchall_exc
     except BadAttributeException as github_broken_exc:  # type: ignore[misc]
         raise RuntimeError(
-            f'Broken GitHub @ {github_api_url !s} with '
-            f'{app_install_context !s}. It is a bug, please report it to the '
-            f'developers.\n\n{github_broken_exc !s}',
+            f'Broken GitHub @ {github_api_url!s} with '
+            f'{app_install_context!s}. It is a bug, please report it to the '
+            f'developers.\n\n{github_broken_exc!s}',
         ) from github_broken_exc
 
 

--- a/src/awx_plugins/credentials/hashivault.py
+++ b/src/awx_plugins/credentials/hashivault.py
@@ -324,10 +324,13 @@ def method_auth(**kwargs):
         request_kwargs['verify'] = cert
         # TLS client certificate support
         if kwargs.get('client_cert_public') and kwargs.get(
-                'client_cert_private',
+            'client_cert_private',
         ):
             # Add client cert to requests Session before making call
-            with CertFiles(kwargs['client_cert_public'], key=kwargs['client_cert_private']) as client_cert:
+            with CertFiles(
+                kwargs['client_cert_public'],
+                key=kwargs['client_cert_private'],
+            ) as client_cert:
                 sess.cert = client_cert
                 resp = sess.post(request_url, **request_kwargs)
         else:
@@ -369,8 +372,9 @@ def kv_backend(**kwargs):
             path_segments = [secret_backend, 'data', secret_path]
         else:
             try:
-                mount_point, * \
-                    path = pathlib.Path(secret_path.lstrip(os.sep)).parts
+                mount_point, *path = pathlib.Path(
+                    secret_path.lstrip(os.sep),
+                ).parts
                 '/'.join(path)
             except Exception:
                 mount_point, path = secret_path, []
@@ -401,9 +405,13 @@ def kv_backend(**kwargs):
 
     if secret_key:
         try:
-            if (secret_key != 'data') and (  # noqa: S105; not a password
+            if (
+                (secret_key != 'data')
+                and (  # noqa: S105; not a password
                     secret_key not in json['data']
-            ) and ('data' in json['data']):
+                )
+                and ('data' in json['data'])
+            ):
                 return json['data']['data'][secret_key]
             return json['data'][secret_key]
         except KeyError:
@@ -427,9 +435,7 @@ def ssh_backend(**kwargs):
         'public_key': kwargs['public_key'],
     }
     if kwargs.get('valid_principals'):
-        request_kwargs['json'][
-            'valid_principals'
-        ] = kwargs['valid_principals']  # type: ignore[index]  # FIXME
+        request_kwargs['json']['valid_principals'] = kwargs['valid_principals']  # type: ignore[index]  # FIXME
 
     sess = requests.Session()
     sess.mount(url, requests.adapters.HTTPAdapter(max_retries=5))

--- a/src/awx_plugins/credentials/hashivault.py
+++ b/src/awx_plugins/credentials/hashivault.py
@@ -435,7 +435,9 @@ def ssh_backend(**kwargs):
         'public_key': kwargs['public_key'],
     }
     if kwargs.get('valid_principals'):
-        request_kwargs['json']['valid_principals'] = kwargs['valid_principals']  # type: ignore[index]  # FIXME
+        request_kwargs['json'][  # type: ignore[index]  # FIXME
+            'valid_principals'
+        ] = kwargs['valid_principals']
 
     sess = requests.Session()
     sess.mount(url, requests.adapters.HTTPAdapter(max_retries=5))

--- a/src/awx_plugins/credentials/injectors.py
+++ b/src/awx_plugins/credentials/injectors.py
@@ -33,7 +33,8 @@ def aws(
     if cred.has_input('security_token'):
         env['AWS_SECURITY_TOKEN'] = str(
             cred.get_input(
-                'security_token', default='',
+                'security_token',
+                default='',
             ),
         )
         env['AWS_SESSION_TOKEN'] = env['AWS_SECURITY_TOKEN']
@@ -133,7 +134,8 @@ def _openstack_data(cred: Credential):
     if cred.has_input('project_domain_name'):
         openstack_auth['project_domain_name'] = str(
             cred.get_input(
-                'project_domain_name', default='',
+                'project_domain_name',
+                default='',
             ),
         )
     if cred.has_input('domain'):
@@ -154,7 +156,8 @@ def _openstack_data(cred: Credential):
     if cred.has_input('region'):
         openstack_data['clouds']['devstack']['region_name'] = str(
             cred.get_input(
-                'region', default='',
+                'region',
+                default='',
             ),
         )
 
@@ -181,9 +184,9 @@ def openstack(
 
 
 def kubernetes_bearer_token(
-        cred: Credential,
-        env: EnvVarsType,
-        private_data_dir: str,
+    cred: Credential,
+    env: EnvVarsType,
+    private_data_dir: str,
 ) -> None:
     env['K8S_AUTH_HOST'] = str(cred.get_input('host', default=''))
     env['K8S_AUTH_API_KEY'] = str(cred.get_input('bearer_token', default=''))
@@ -196,7 +199,8 @@ def kubernetes_bearer_token(
             os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
             f.write(str(cred.get_input('ssl_ca_cert')))
         env['K8S_AUTH_SSL_CA_CERT'] = get_incontainer_path(
-            path, private_data_dir,
+            path,
+            private_data_dir,
         )
     else:
         env['K8S_AUTH_VERIFY_SSL'] = 'False'
@@ -212,7 +216,8 @@ def terraform(
         os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
         f.write(str(cred.get_input('configuration')))
     env['TF_BACKEND_CONFIG_FILE'] = get_incontainer_path(
-        path, private_data_dir,
+        path,
+        private_data_dir,
     )
     # Handle env variables for GCP account credentials
     if cred.has_input('gce_credentials'):
@@ -223,5 +228,6 @@ def terraform(
             os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
             f.write(str(cred.get_input('gce_credentials')))
         env['GOOGLE_BACKEND_CREDENTIALS'] = get_incontainer_path(
-            path, private_data_dir,
+            path,
+            private_data_dir,
         )

--- a/src/awx_plugins/credentials/plugins.py
+++ b/src/awx_plugins/credentials/plugins.py
@@ -651,10 +651,15 @@ rhv = ManagedCredentialType(
     inputs={
         'fields': [
             {
-                'id': 'host', 'label': gettext_noop('Host (Authentication URL)'), 'type': 'string', 'help_text': gettext_noop('The host to authenticate with.'),
+                'id': 'host',
+                'label': gettext_noop('Host (Authentication URL)'),
+                'type': 'string',
+                'help_text': gettext_noop('The host to authenticate with.'),
             },
             {
-                'id': 'username', 'label': gettext_noop('Username'), 'type': 'string',
+                'id': 'username',
+                'label': gettext_noop('Username'),
+                'type': 'string',
             },
             {
                 'id': 'password',
@@ -666,7 +671,9 @@ rhv = ManagedCredentialType(
                 'id': 'ca_file',
                 'label': gettext_noop('CA File'),
                 'type': 'string',
-                'help_text': gettext_noop('Absolute file path to the CA file to use (optional)'),
+                'help_text': gettext_noop(
+                    'Absolute file path to the CA file to use (optional)',
+                ),
             },
         ],
         'required': ['host', 'username', 'password'],

--- a/src/awx_plugins/credentials/tss.py
+++ b/src/awx_plugins/credentials/tss.py
@@ -89,7 +89,9 @@ def tss_backend(**kwargs):
         )
     else:
         authorizer = PasswordGrantAuthorizer(
-            kwargs['server_url'], kwargs['username'], kwargs['password'],
+            kwargs['server_url'],
+            kwargs['username'],
+            kwargs['password'],
         )
     secret_server = SecretServer(kwargs['server_url'], authorizer)
     secret_dict = secret_server.get_secret(kwargs['secret_id'])

--- a/src/awx_plugins/inventory/plugins.py
+++ b/src/awx_plugins/inventory/plugins.py
@@ -26,7 +26,9 @@ class PluginFileInjector:
     # every source should have collection, these are for the collection name
     namespace = None
     collection = None
-    collection_migration = '2.9'  # Starting with this version, we use collections
+    collection_migration = (
+        '2.9'  # Starting with this version, we use collections
+    )
     use_fqcn = False  # plugin: name versus plugin: namespace.collection.name
 
     # TODO: delete this method and update unit tests
@@ -65,24 +67,24 @@ class PluginFileInjector:
         Note that a plugin value of '' should still be overridden.
         """
         if self.plugin_name is not None:
-            source_vars['plugin'] = f"""{
-                self.namespace
-            }.{
-                self.collection
-            }.{
-                self.plugin_name
-            }""" if self.use_fqcn else self.plugin_name
+            source_vars['plugin'] = (
+                f"""{self.namespace}.{self.collection}.{self.plugin_name}"""
+                if self.use_fqcn
+                else self.plugin_name
+            )
         return source_vars
 
     def build_env(
-            self,
-            inventory_update,
-            env,
-            private_data_dir,
-            private_data_files,
+        self,
+        inventory_update,
+        env,
+        private_data_dir,
+        private_data_files,
     ):
         injector_env = self.get_plugin_env(
-            inventory_update, private_data_dir, private_data_files,
+            inventory_update,
+            private_data_dir,
+            private_data_files,
         )
         env.update(injector_env)
         # All CLOUD_PROVIDERS sources implement as inventory plugin from
@@ -91,10 +93,10 @@ class PluginFileInjector:
         return env
 
     def _get_shared_env(
-            self,
-            inventory_update,
-            private_data_dir,
-            private_data_files,
+        self,
+        inventory_update,
+        private_data_dir,
+        private_data_files,
     ):  # noqa: DAR101, DAR201; FIXME
         """By default, we will apply the standard managed injectors."""
         if self.base_injector not in {'managed', 'template'}:
@@ -123,7 +125,11 @@ class PluginFileInjector:
             safe_env = injected_env.copy()
             args = []
             credential.credential_type.inject_credential(
-                credential, injected_env, safe_env, args, private_data_dir,
+                credential,
+                injected_env,
+                safe_env,
+                args,
+                private_data_dir,
             )
             # NOTE: safe_env is handled externally to injector class by build_safe_env static method
             # that means that managed injectors must only inject detectable env keys
@@ -131,10 +137,10 @@ class PluginFileInjector:
         return injected_env
 
     def get_plugin_env(
-            self,
-            inventory_update,
-            private_data_dir,
-            private_data_files,
+        self,
+        inventory_update,
+        private_data_dir,
+        private_data_files,
     ):
         env = self._get_shared_env(
             inventory_update,
@@ -145,7 +151,8 @@ class PluginFileInjector:
 
     def build_private_data(self, inventory_update, private_data_dir):
         return self.build_plugin_private_data(
-            inventory_update, private_data_dir,
+            inventory_update,
+            private_data_dir,
         )
 
     def build_plugin_private_data(self, inventory_update, private_data_dir):
@@ -220,8 +227,11 @@ class openstack(PluginFileInjector):
     def _get_clouds_dict(self, inventory_update, cred, private_data_dir):
         openstack_data = _openstack_data(cred)
 
-        openstack_data['clouds']['devstack']['private'] = inventory_update.source_vars_dict.get(
-            'private', True,
+        openstack_data['clouds']['devstack']['private'] = (
+            inventory_update.source_vars_dict.get(
+                'private',
+                True,
+            )
         )
         ansible_variables = {
             'use_hostnames': True,
@@ -231,7 +241,9 @@ class openstack(PluginFileInjector):
         provided_count = 0
         for var_name in ansible_variables:
             if var_name in inventory_update.source_vars_dict:
-                ansible_variables[var_name] = inventory_update.source_vars_dict[var_name]
+                ansible_variables[var_name] = (
+                    inventory_update.source_vars_dict[var_name]
+                )
                 provided_count += 1
         if provided_count:
             # Must we provide all 3 because the user provides any 1 of these??
@@ -244,18 +256,22 @@ class openstack(PluginFileInjector):
         private_data = {'credentials': {}}
 
         openstack_data = self._get_clouds_dict(
-            inventory_update, credential, private_data_dir,
+            inventory_update,
+            credential,
+            private_data_dir,
         )
         private_data['credentials'][credential] = yaml.safe_dump(
-            openstack_data, default_flow_style=False, allow_unicode=True,
+            openstack_data,
+            default_flow_style=False,
+            allow_unicode=True,
         )
         return private_data
 
     def get_plugin_env(
-            self,
-            inventory_update,
-            private_data_dir,
-            private_data_files,
+        self,
+        inventory_update,
+        private_data_dir,
+        private_data_files,
     ):
         env = super().get_plugin_env(
             inventory_update,
@@ -265,7 +281,8 @@ class openstack(PluginFileInjector):
         credential = inventory_update.get_cloud_credential()
         cred_data = private_data_files['credentials']
         env['OS_CLIENT_CONFIG_FILE'] = get_incontainer_path(
-            cred_data[credential], private_data_dir,
+            cred_data[credential],
+            private_data_dir,
         )
         return env
 
@@ -302,10 +319,10 @@ class satellite6(PluginFileInjector):
     use_fqcn = True
 
     def get_plugin_env(
-            self,
-            inventory_update,
-            private_data_dir,
-            private_data_files,
+        self,
+        inventory_update,
+        private_data_dir,
+        private_data_files,
     ):
         # this assumes that this is merged
         # https://github.com/ansible/ansible/pull/52693
@@ -319,7 +336,8 @@ class satellite6(PluginFileInjector):
             ret['FOREMAN_SERVER'] = credential.get_input('host', default='')
             ret['FOREMAN_USER'] = credential.get_input('username', default='')
             ret['FOREMAN_PASSWORD'] = credential.get_input(
-                'password', default='',
+                'password',
+                default='',
             )
         return ret
 
@@ -332,10 +350,10 @@ class satellite6_supported(PluginFileInjector):
     use_fqcn = True
 
     def get_plugin_env(
-            self,
-            inventory_update,
-            private_data_dir,
-            private_data_files,
+        self,
+        inventory_update,
+        private_data_dir,
+        private_data_files,
     ):
         # this assumes that this is merged
         # https://github.com/ansible/ansible/pull/52693
@@ -349,7 +367,8 @@ class satellite6_supported(PluginFileInjector):
             ret['FOREMAN_SERVER'] = credential.get_input('host', default='')
             ret['FOREMAN_USER'] = credential.get_input('username', default='')
             ret['FOREMAN_PASSWORD'] = credential.get_input(
-                'password', default='',
+                'password',
+                default='',
             )
         return ret
 
@@ -373,7 +392,8 @@ class terraform(PluginFileInjector):
                 os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
                 f.write(config_cred)
             ret['backend_config_files'] = get_incontainer_path(
-                path, private_data_dir,
+                path,
+                private_data_dir,
             )
         return ret
 
@@ -387,10 +407,10 @@ class terraform(PluginFileInjector):
         return private_data
 
     def get_plugin_env(
-            self,
-            inventory_update,
-            private_data_dir,
-            private_data_files,
+        self,
+        inventory_update,
+        private_data_dir,
+        private_data_files,
     ):
         env = super().get_plugin_env(
             inventory_update,
@@ -401,7 +421,8 @@ class terraform(PluginFileInjector):
         cred_data = private_data_files['credentials']
         if credential in cred_data:
             env['GOOGLE_BACKEND_CREDENTIALS'] = get_incontainer_path(
-                cred_data[credential], private_data_dir,
+                cred_data[credential],
+                private_data_dir,
             )
         return env
 
@@ -435,7 +456,10 @@ class insights(PluginFileInjector):
     use_fqcn = True
 
     def inventory_as_dict(self, inventory_update, private_data_dir):
-        inventory_data = super().inventory_as_dict(inventory_update, private_data_dir)
+        inventory_data = super().inventory_as_dict(
+            inventory_update,
+            private_data_dir,
+        )
         credential = inventory_update.get_cloud_credential()
         if credential.get_input('client_id', default=''):
             inventory_data['authentication'] = 'service_account'
@@ -452,7 +476,10 @@ class insights_supported(PluginFileInjector):
     use_fqcn = True
 
     def inventory_as_dict(self, inventory_update, private_data_dir):
-        inventory_data = super().inventory_as_dict(inventory_update, private_data_dir)
+        inventory_data = super().inventory_as_dict(
+            inventory_update,
+            private_data_dir,
+        )
         credential = inventory_update.get_cloud_credential()
         if credential.get_input('client_id', default=''):
             inventory_data['authentication'] = 'service_account'

--- a/tests/credential_plugins_test.py
+++ b/tests/credential_plugins_test.py
@@ -167,10 +167,10 @@ class TestDelineaImports:
         )
 
         for cls in (
-                DomainPasswordGrantAuthorizer,
-                PasswordGrantAuthorizer,
-                SecretServer,
-                ServerSecret,
+            DomainPasswordGrantAuthorizer,
+            PasswordGrantAuthorizer,
+            SecretServer,
+            ServerSecret,
         ):
             # assert this module as opposed to older thycotic.secrets.server
             assert cls.__module__ == 'delinea.secrets.server'

--- a/tests/importable_test.py
+++ b/tests/importable_test.py
@@ -198,7 +198,7 @@ def test_entry_points_exposed(entry_point: EntryPointParam) -> None:
 
 @with_credential_plugins
 def test_entry_points_are_credential_plugin(
-        entry_point: EntryPointParam,
+    entry_point: EntryPointParam,
 ) -> None:
     """Ensure all exposed credential plugins are of the same class."""  # noqa: D200, DAR101; FIXME
     entry_points = _discover_entry_points(group=entry_point.group)
@@ -210,7 +210,7 @@ def test_entry_points_are_credential_plugin(
 
 @with_inventory_plugins
 def test_entry_points_are_inventory_plugin(
-        entry_point: EntryPointParam,
+    entry_point: EntryPointParam,
 ) -> None:
     """Ensure all exposed inventory plugins are of the same class."""  # noqa: D200, DAR101; FIXME
     entry_points = _discover_entry_points(group=entry_point.group)

--- a/tests/managed_credential_plugins_test.py
+++ b/tests/managed_credential_plugins_test.py
@@ -1,4 +1,5 @@
 """Individual ManagedCredentialType plugin tests."""
+
 import configparser
 import json
 from dataclasses import dataclass
@@ -146,7 +147,9 @@ class JsonEnvFile(BaseEnvFile[dict[str, str] | MappingProxyType[str, str]]):
         :param private_data_dir: directory to read the file from
         :returns: None
         """
-        with open(to_host_path(str(env[self.env_key]), private_data_dir)) as fh:
+        with open(
+            to_host_path(str(env[self.env_key]), private_data_dir),
+        ) as fh:
             assert self.expected_data.items() == json.load(fh).items()
 
 
@@ -164,7 +167,9 @@ class StringEnvFile(BaseEnvFile[str]):
         :param private_data_dir: directory to read the file from
         :returns: None
         """
-        with open(to_host_path(str(env[self.env_key]), private_data_dir)) as fh:
+        with open(
+            to_host_path(str(env[self.env_key]), private_data_dir),
+        ) as fh:
             assert self.expected_data == fh.read()
 
 
@@ -203,7 +208,9 @@ class YamlEnvFile(BaseEnvFile[dict[str, IniEntryDataType]]):
         :param private_data_dir: directory to read the file from
         :returns: None
         """
-        with open(to_host_path(str(env[self.env_key]), private_data_dir)) as fh:
+        with open(
+            to_host_path(str(env[self.env_key]), private_data_dir),
+        ) as fh:
             assert self.expected_data.items() == yaml.safe_load(fh).items()
 
 
@@ -275,7 +282,8 @@ class YamlEnvFile(BaseEnvFile[dict[str, IniEntryDataType]]):
             {},
             [
                 JsonEnvFile(
-                    'GCE_CREDENTIALS_FILE_PATH', {
+                    'GCE_CREDENTIALS_FILE_PATH',
+                    {
                         'type': 'service_account',
                         'private_key': EXAMPLE_PRIVATE_KEY,
                         'client_email': 'tony',
@@ -351,7 +359,8 @@ class YamlEnvFile(BaseEnvFile[dict[str, IniEntryDataType]]):
             {},
             [
                 YamlEnvFile(
-                    'OS_CLIENT_CONFIG_FILE', {
+                    'OS_CLIENT_CONFIG_FILE',
+                    {
                         'clouds': {
                             'devstack': {
                                 'auth': {
@@ -379,7 +388,8 @@ class YamlEnvFile(BaseEnvFile[dict[str, IniEntryDataType]]):
             {},
             [
                 IniEnvFile(
-                    'OVIRT_INI_PATH', {
+                    'OVIRT_INI_PATH',
+                    {
                         'ovirt': {
                             'ovirt_url': 'rick.example.org',
                             'ovirt_username': 'rick',
@@ -402,7 +412,8 @@ class YamlEnvFile(BaseEnvFile[dict[str, IniEntryDataType]]):
             {},
             [
                 IniEnvFile(
-                    'OVIRT_INI_PATH', {
+                    'OVIRT_INI_PATH',
+                    {
                         'ovirt': {
                             'ovirt_url': 'rick.example.org',
                             'ovirt_username': 'rick',


### PR DESCRIPTION
This patch adds a double-pass of `ruff format` to help it settle suggestions from `add-trailing-comma` during a single `pre-commit` run.
It also blame-ignores a dedicated formatting commit to help with future Git paleontology.