### PR TITLE
🧪 Disable checking for S106 with Ruff in tests

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -153,6 +153,7 @@ testing = [
   "PLR6301", # Allow 'self' parameter in method definitions (required for test stubs)
   "S101",    # Allow use of `assert` in test files
   "S105",    # hardcoded-password-string
+  "S106",    # hardcoded-password-func-arg
   "S108",    # tmp dirs
   "S404",    # Allow importing 'subprocess' module to testing call external tools needed by these hooks
   "S603",    # subprocess calls


### PR DESCRIPTION
This rule [[1]] is important in runtime code, but is okay in tests.

[1]: https://docs.astral.sh/ruff/rules/hardcoded-password-func-arg/