### PR TITLE
🧪 Integrate `no-optional` into pre-commit tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
     - file
     - symlink
 
+- repo: https://github.com/Kludex/no-optional.git
+  rev: 0.4.0
+  hooks:
+  - id: no_optional
+
 - repo: https://github.com/astral-sh/ruff-pre-commit.git
   rev: v0.11.6
   hooks:


### PR DESCRIPTION
This is a simple formatter that replaces the use of `typing.Optional` with a `typing.Union` equivalent. It runs before the style formatters.

`Optional[T]` is considered confusing because it actually means `T | None` which is a union of two types.