### PR TITLE
Set defaults for optional values in azure_kv plugin

### DIFF
--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -121,11 +121,11 @@ def _initialize_credential(
 def azure_keyvault_backend(  # noqa: WPS211
     *,
     url: str,
-    client: str,
-    secret: str,
-    tenant: str,
+    client: str = '',
+    secret: str = '',
+    tenant: str = '',
     secret_field: str,
-    secret_version: str,
+    secret_version: str = '',
 ) -> str | None:
     """Get a credential and retrieve a secret from an Azure Key Vault.
 


### PR DESCRIPTION
The integration tests don't pass in an empty string like I assumed the UI does so tests are failing when optional arguments aren't given. This sets the default for the optional arguments to an empty string. I considered setting them to `str | None` but that introduced other typing issues.