### PR TITLE
🧪 Move `--all-extras` from pip-tools cfg to GHA

### DIFF
--- a/.github/workflows/pip-tools.yml
+++ b/.github/workflows/pip-tools.yml
@@ -100,11 +100,11 @@ jobs:
         - tox
         - spellcheck-docs
         lock-file-extra-input:
-        - pyproject.toml
+        - pyproject.toml --all-extras
         - ''
         exclude:
         - lock-file-env: build-dists
-          lock-file-extra-input: pyproject.toml
+          lock-file-extra-input: pyproject.toml --all-extras
         - lock-file-env: build-docs
           lock-file-extra-input: ''
         - lock-file-env: codelinter-docs
@@ -116,19 +116,19 @@ jobs:
         - lock-file-env: linkcheck-docs
           lock-file-extra-input: ''
         - lock-file-env: metadata-validation
-          lock-file-extra-input: pyproject.toml
+          lock-file-extra-input: pyproject.toml --all-extras
         - lock-file-env: pip-compile
-          lock-file-extra-input: pyproject.toml
+          lock-file-extra-input: pyproject.toml --all-extras
         - lock-file-env: pip-compile-build-lock
-          lock-file-extra-input: pyproject.toml
+          lock-file-extra-input: pyproject.toml --all-extras
         - lock-file-env: pip-compile-tox-env-lock
-          lock-file-extra-input: pyproject.toml
+          lock-file-extra-input: pyproject.toml --all-extras
         - lock-file-env: pre-commit
-          lock-file-extra-input: pyproject.toml
+          lock-file-extra-input: pyproject.toml --all-extras
         - lock-file-env: py
           lock-file-extra-input: ''
         - lock-file-env: tox
-          lock-file-extra-input: pyproject.toml
+          lock-file-extra-input: pyproject.toml --all-extras
         - lock-file-env: spellcheck-docs
           lock-file-extra-input: ''
 

--- a/.pip-tools.toml
+++ b/.pip-tools.toml
@@ -1,6 +1,5 @@
 [tool.pip-tools]
 allow-unsafe = true  # weird outdated default
-all-extras = true  # so that all optional dependencies are considered
 generate-hashes = false  # pip bug https://github.com/pypa/pip/issues/9243
 resolver = "backtracking"  # modern depresolver
 strip-extras = true  # so that output files are true pip constraints


### PR DESCRIPTION
This is necessary so that it doesn't conflict with `--only-build-deps` when it's passed on CLI.

This implements what's asked @ https://github.com/ansible/awx-plugins/pull/52#issuecomment-2445712910.