### PR TITLE
Add support for Iv2-prefixed Client IDs into Github App Credential

### DIFF
--- a/src/awx_plugins/credentials/github_app.py
+++ b/src/awx_plugins/credentials/github_app.py
@@ -79,11 +79,11 @@ github_app_inputs: GitHubAppInputs = {
         },
         {
             'id': 'app_or_client_id',
-            'label': _('GitHub App ID'),
+            'label': _('GitHub App ID or Client ID'),
             'type': 'string',
             'help_text': _(
-                'The GitHub App ID created by the GitHub Admin. '
-                'Example App ID: 1121547 '
+                'The GitHub App ID or Client ID created by the GitHub Admin. '
+                'Example App ID: 1121547, Client ID: Iv23likIfIXeZTb5GCAA '
                 'found on https://github.com/settings/apps/ '
                 'required for creating a JWT token for authentication.',
             ),
@@ -130,65 +130,6 @@ class EmptyKwargs(TypedDict):
     """Schema for zero keyword arguments."""
 
 
-GH_CLIENT_ID_TRAILER_LENGTH = 16
-HEXADECIMAL_BASE = 16
-
-
-def _is_intish(app_id_candidate: str | int) -> bool:
-    return isinstance(app_id_candidate, int) or app_id_candidate.isdigit()
-
-
-def _is_client_id(client_id_candidate: str) -> bool:
-    client_id_prefix = 'Iv1.'
-    if not client_id_candidate.startswith(client_id_prefix):
-        return False
-
-    client_id_trailer = client_id_candidate.removeprefix(client_id_prefix)
-
-    if len(client_id_trailer) != GH_CLIENT_ID_TRAILER_LENGTH:
-        return False
-
-    try:
-        int(client_id_trailer, base=HEXADECIMAL_BASE)
-    except ValueError:
-        return False
-
-    return True
-
-
-def _is_app_or_client_id(app_or_client_id_candidate: str | int) -> bool:
-    if _is_intish(app_or_client_id_candidate):
-        return True
-
-    assert not isinstance(app_or_client_id_candidate, int)  # type narrowing
-    return _is_client_id(app_or_client_id_candidate)
-
-
-def _assert_ids_look_acceptable(
-    app_or_client_id: int | str,
-    install_id: int | str,
-) -> None:
-    if not _is_app_or_client_id(app_or_client_id):
-        raise ValueError(
-            'Expected GitHub App or Client ID to be an integer or a string '
-            f'starting with `Iv1.` followed by 16 hexadecimal digits, '
-            f'but got {app_or_client_id!r}',
-        )
-
-    if isinstance(app_or_client_id, str) and _is_client_id(app_or_client_id):
-        raise ValueError(
-            'Expected GitHub App ID must be an integer or a string '
-            f'with an all-digit value, but got {app_or_client_id!r}. '
-            'Client IDs are currently unsupported.',
-        )
-
-    if not _is_intish(install_id):
-        raise ValueError(
-            'Expected GitHub App Installation ID to be an integer'
-            f' but got {install_id!r}',
-        )
-
-
 def extract_github_app_install_token(  # noqa: WPS210
     *,
     github_api_url: str,
@@ -200,17 +141,15 @@ def extract_github_app_install_token(  # noqa: WPS210
     """Generate a GH App Installation access token.
 
     :param github_api_url: The GitHub instance API endpoint URL.
-    :param app_or_client_id: The GitHub App ID.
+    :param app_or_client_id: The GitHub App ID or Client ID.
     :param private_rsa_key: The private key associated with the GitHub
         App.
     :param install_id: The GitHub App Installation ID.
     :param _discarded_kwargs: Aren't expected to be passed.
     :returns: A GitHub access token for a GitHub App Installation.
-    :raises ValueError: If any required parameters are invalid.
-    :raises RuntimeError: If any required parameters are invalid.
+    :raises ValueError: If authentication fails or parameters are invalid.
+    :raises RuntimeError: If an unexpected error occurs during token generation.
     """
-    _assert_ids_look_acceptable(app_or_client_id, install_id)
-
     auth = Auth.AppAuth(
         app_id=str(app_or_client_id),
         private_key=private_rsa_key,

--- a/tests/github_app_test.py
+++ b/tests/github_app_test.py
@@ -29,14 +29,6 @@ from jwt import decode as decode_jwt
 from awx_plugins.credentials import github_app as gh_app_plugin_mod
 
 
-github_app_jwt_client_id_unsupported = pytest.mark.xfail(
-    raises=(AssertionError, ValueError),
-    reason='Client ID in JWT is not currently supported by '
-    'PyGitHub and is disabled.\n\n'
-    'Ref: https://github.com/PyGithub/PyGithub/issues/3213',
-)
-
-
 RSA_PUBLIC_EXPONENT = 65_537  # noqa: WPS303
 MINIMUM_RSA_KEY_SIZE = 1024  # the lowest value chosen for performance in tests
 
@@ -95,92 +87,6 @@ class AppInstallIds(TypedDict):
 
     app_or_client_id: str
     install_id: str
-
-
-@pytest.mark.parametrize(
-    ('extract_github_app_install_token_args', 'expected_error_msg'),
-    (
-        pytest.param(
-            {
-                'app_or_client_id': 'invalid',
-                'install_id': '666',
-            },
-            '^Expected GitHub App or Client ID to be an integer or a string '
-            r'starting with `Iv1\.` followed by 16 hexadecimal digits, but got'
-            " 'invalid'$",
-            id='gh-app-id-broken-text',
-        ),
-        pytest.param(
-            {
-                'app_or_client_id': 'Iv1.bbbbbbbbbbbbbbb',
-                'install_id': '666',
-            },
-            '^Expected GitHub App or Client ID to be an integer or a string '
-            r'starting with `Iv1\.` followed by 16 hexadecimal digits, but got'
-            " 'Iv1.bbbbbbbbbbbbbbb'$",
-            id='gh-app-id-client-id-not-enough-chars',
-        ),
-        pytest.param(
-            {
-                'app_or_client_id': 'Iv1.bbbbbbbbbbbbbbbx',
-                'install_id': '666',
-            },
-            '^Expected GitHub App or Client ID to be an integer or a string '
-            r'starting with `Iv1\.` followed by 16 hexadecimal digits, but got'
-            " 'Iv1.bbbbbbbbbbbbbbbx'$",
-            id='gh-app-id-client-id-broken-hex',
-        ),
-        pytest.param(
-            {
-                'app_or_client_id': 'Iv1.bbbbbbbbbbbbbbbbb',
-                'install_id': '666',
-            },
-            '^Expected GitHub App or Client ID to be an integer or a string '
-            r'starting with `Iv1\.` followed by 16 hexadecimal digits, but got'
-            " 'Iv1.bbbbbbbbbbbbbbbbb'$",
-            id='gh-app-id-client-id-too-many-chars',
-        ),
-        pytest.param(
-            {
-                'app_or_client_id': 999,
-                'install_id': 'invalid',
-            },
-            '^Expected GitHub App Installation ID to be an integer '
-            "but got 'invalid'$",
-            id='gh-app-invalid-install-id-with-int-app-id',
-        ),
-        pytest.param(
-            {
-                'app_or_client_id': '999',
-                'install_id': 'invalid',
-            },
-            '^Expected GitHub App Installation ID to be an integer '
-            "but got 'invalid'$",
-            id='gh-app-invalid-install-id-with-str-digit-app-id',
-        ),
-        pytest.param(
-            {
-                'app_or_client_id': 'Iv1.cccccccccccccccc',
-                'install_id': 'invalid',
-            },
-            '^Expected GitHub App Installation ID to be an integer '
-            "but got 'invalid'$",
-            id='gh-app-invalid-install-id-with-client-id',
-            marks=github_app_jwt_client_id_unsupported,
-        ),
-    ),
-)
-def test_github_app_invalid_args(
-    extract_github_app_install_token_args: AppInstallIds,
-    expected_error_msg: str,
-) -> None:
-    """Test that invalid arguments make token extractor bail early."""
-    with pytest.raises(ValueError, match=expected_error_msg):
-        gh_app_plugin_mod.extract_github_app_install_token(
-            github_api_url='https://github.com',
-            private_rsa_key='key',
-            **extract_github_app_install_token_args,
-        )
 
 
 @pytest.mark.parametrize(
@@ -271,16 +177,16 @@ class _FakeAppInstallationAuth(AppInstallationAuth):
 
 
 @pytest.mark.parametrize(
-    'application_id',
+    'application_or_client_id',
     (
         123,
         '123',
-        pytest.param(
-            'Iv1.aaaaaaaaaaaaaaaa',
-            marks=github_app_jwt_client_id_unsupported,
-        ),
+        'Iv1.aaaaaaaaaaaaaaaa',
+        'Iv2aaaaaaaaaaaaaaaa',
+        'Iv10aaaaaaaaaaaaaaaa',
+        'Iv100.aaaaaaaaaaaaaaaa',
+        'Iv23likIfIXeZTb5GCAA',
     ),
-    ids=('app-id-int', 'app-id-str', 'client-id'),
 )
 @pytest.mark.parametrize(
     'installation_id',
@@ -289,7 +195,7 @@ class _FakeAppInstallationAuth(AppInstallationAuth):
 )
 # pylint: disable-next=too-many-arguments,too-many-positional-arguments
 def test_github_app_github_authentication(  # noqa: WPS211
-    application_id: int | str,
+    application_or_client_id: int | str,
     installation_id: int | str,
     mocker: MockerFixture,
     monkeypatch: pytest.MonkeyPatch,
@@ -311,7 +217,7 @@ def test_github_app_github_authentication(  # noqa: WPS211
 
     token = gh_app_plugin_mod.extract_github_app_install_token(
         github_api_url='https://github.com',
-        app_or_client_id=application_id,
+        app_or_client_id=application_or_client_id,
         install_id=installation_id,
         private_rsa_key=rsa_private_key_str,
     )
@@ -346,6 +252,6 @@ def test_github_app_github_authentication(  # noqa: WPS211
             'verify_nbf': True,
         },
         audience=None,  # GH App JWT don't set the audience claim
-        issuer=str(application_id),
+        issuer=str(application_or_client_id),
         leeway=0.001,  # noqa: WPS432
     )

--- a/tests/github_app_test.py
+++ b/tests/github_app_test.py
@@ -31,6 +31,7 @@ from awx_plugins.credentials import github_app as gh_app_plugin_mod
 
 RSA_PUBLIC_EXPONENT = 65_537  # noqa: WPS303
 MINIMUM_RSA_KEY_SIZE = 1024  # the lowest value chosen for performance in tests
+TEST_APP_ID = 123
 
 
 @pytest.fixture(scope='module')
@@ -179,13 +180,13 @@ class _FakeAppInstallationAuth(AppInstallationAuth):
 @pytest.mark.parametrize(
     'application_or_client_id',
     (
-        123,
-        '123',
-        'Iv1.aaaaaaaaaaaaaaaa',
-        'Iv2aaaaaaaaaaaaaaaa',
-        'Iv10aaaaaaaaaaaaaaaa',
-        'Iv100.aaaaaaaaaaaaaaaa',
-        'Iv23likIfIXeZTb5GCAA',
+        pytest.param(TEST_APP_ID, id='app-id-int'),
+        pytest.param(str(TEST_APP_ID), id='app-id-str'),
+        pytest.param('Iv1.aaaaaaaaaaaaaaaa', id='client-id-iv1-legacy-format'),
+        pytest.param('Iv2aaaaaaaaaaaaaaaa', id='client-id-iv2-new-format'),
+        pytest.param('Iv10aaaaaaaaaaaaaaaa', id='client-id-iv10-double-digit-version'),
+        pytest.param('Iv100.aaaaaaaaaaaaaaaa', id='client-id-iv100-with-dot'),
+        pytest.param('Iv23likIfIXeZTb5GCAA', id='client-id-iv23-real-example'),
     ),
 )
 @pytest.mark.parametrize(

--- a/tests/github_app_test.py
+++ b/tests/github_app_test.py
@@ -184,7 +184,10 @@ class _FakeAppInstallationAuth(AppInstallationAuth):
         pytest.param(str(TEST_APP_ID), id='app-id-str'),
         pytest.param('Iv1.aaaaaaaaaaaaaaaa', id='client-id-iv1-legacy-format'),
         pytest.param('Iv2aaaaaaaaaaaaaaaa', id='client-id-iv2-new-format'),
-        pytest.param('Iv10aaaaaaaaaaaaaaaa', id='client-id-iv10-double-digit-version'),
+        pytest.param(
+            'Iv10aaaaaaaaaaaaaaaa',
+            id='client-id-iv10-double-digit-version',
+        ),
         pytest.param('Iv100.aaaaaaaaaaaaaaaa', id='client-id-iv100-with-dot'),
         pytest.param('Iv23likIfIXeZTb5GCAA', id='client-id-iv23-real-example'),
     ),


### PR DESCRIPTION
As Github encourages more the use of Client IDs, one can create a Github App Installation Lookup App Credential using Github Client IDs starting with Iv1. However, using Iv2 will throw an error.

Fixes: as Github is providing Client IDs starting with Iv2, Credentials should be able to be created with it. The changes in this PR adds support for Iv2, enabling Credentials to be created using them.  

