### PR TITLE
Add a managed credential type for HCP Terraform

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ insights = "awx_plugins.credentials.plugins:insights"
 rhv = "awx_plugins.credentials.plugins:rhv"
 gpg_public_key = "awx_plugins.credentials.plugins:gpg_public_key"
 terraform = "awx_plugins.credentials.plugins:terraform"
+hcp_terraform = "awx_plugins.credentials._managed_types.terraform:hcp_terraform"
 
 [project.entry-points."awx_plugins.inventory"]  # new entry points group name
 azure_rm = "awx_plugins.inventory.plugins:azure_rm"

--- a/src/awx_plugins/credentials/_managed_types/terraform.py
+++ b/src/awx_plugins/credentials/_managed_types/terraform.py
@@ -1,0 +1,46 @@
+"""HCP Terraform managed credential type."""
+
+from awx_plugins.interfaces._temporary_private_api import (  # noqa: WPS436
+    ManagedCredentialType,
+)
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop,
+)
+
+from ..injectors import hcp_terraform as hcp_terraform_injector
+
+
+# FIXME: ManagedCredentialType and gettext_noop return Any from
+# _temporary_private_api interfaces. These nested Any structures cascade
+# into making outer dicts/lists typed as Any as well, requiring suppressions
+# throughout. Remove once those interfaces have proper type annotations.
+hcp_terraform = ManagedCredentialType(  # type: ignore[misc]
+    namespace='hcp_terraform',
+    kind='cloud',
+    name=gettext_noop('HCP Terraform'),  # type: ignore[misc]
+    managed=True,
+    custom_injectors=hcp_terraform_injector,
+    inputs={
+        'fields': [  # type: ignore[misc]
+            {  # type: ignore[misc]
+                'id': 'hostname',
+                'label': gettext_noop('Hostname'),  # type: ignore[misc]
+                'type': 'string',
+                'help_text': gettext_noop(  # type: ignore[misc]
+                    'The hostname of your HCP Terraform instance (e.g., app.terraform.io)',
+                ),
+                'default': 'app.terraform.io',
+            },
+            {  # type: ignore[misc]
+                'id': 'token',
+                'label': gettext_noop('API Token'),  # type: ignore[misc]
+                'type': 'string',
+                'secret': True,
+                'help_text': gettext_noop(  # type: ignore[misc]
+                    'HCP Terraform API Token',
+                ),
+            },
+        ],
+        'required': ['token'],
+    },
+)

--- a/src/awx_plugins/credentials/injectors.py
+++ b/src/awx_plugins/credentials/injectors.py
@@ -231,3 +231,14 @@ def terraform(
             path,
             private_data_dir,
         )
+
+
+def hcp_terraform(
+    cred: Credential,
+    env: EnvVarsType,
+    private_data_dir: str,
+) -> None:
+    env['TF_TOKEN'] = str(cred.get_input('token', default=''))
+    env['TF_HOSTNAME'] = str(
+        cred.get_input('hostname', default='app.terraform.io'),
+    )

--- a/tests/importable_test.py
+++ b/tests/importable_test.py
@@ -73,6 +73,15 @@ credential_plugins = (
 )
 
 
+managed_credential_plugins = (
+    EntryPointParam(
+        'awx_plugins.managed_credentials.supported',
+        'hcp_terraform',
+        'awx_plugins.credentials._managed_types.terraform:hcp_terraform',
+    ),
+)
+
+
 inventory_plugins = (
     EntryPointParam(
         'awx_plugins.inventory',
@@ -174,6 +183,13 @@ with_credential_plugins = pytest.mark.parametrize(
 )
 
 
+with_managed_credential_plugins = pytest.mark.parametrize(
+    'entry_point',
+    managed_credential_plugins,
+    ids=str,
+)
+
+
 with_inventory_plugins = pytest.mark.parametrize(
     'entry_point',
     inventory_plugins,
@@ -183,7 +199,7 @@ with_inventory_plugins = pytest.mark.parametrize(
 
 with_all_plugins = pytest.mark.parametrize(
     'entry_point',
-    credential_plugins + inventory_plugins,
+    credential_plugins + managed_credential_plugins + inventory_plugins,
     ids=str,
 )
 
@@ -211,6 +227,18 @@ def test_entry_points_are_credential_plugin(
 
     loaded_plugin_class_name = type(loaded_plugin_class).__name__
     assert loaded_plugin_class_name == 'CredentialPlugin'
+
+
+@with_managed_credential_plugins
+def test_entry_points_are_managed_credential_type(
+    entry_point: EntryPointParam,
+) -> None:
+    """Ensure all exposed managed credential plugins are of the same class."""  # noqa: D200, DAR101; FIXME
+    entry_points = _discover_entry_points(group=entry_point.group)
+    loaded_plugin_class = entry_points[entry_point.name].load()
+
+    loaded_plugin_class_name = type(loaded_plugin_class).__name__
+    assert loaded_plugin_class_name == 'ManagedCredentialType'
 
 
 @with_inventory_plugins

--- a/tests/managed_credential_plugins_test.py
+++ b/tests/managed_credential_plugins_test.py
@@ -28,6 +28,7 @@ from awx_plugins.interfaces._temporary_private_inject_api import (  # noqa: WPS4
 
 import yaml
 
+from awx_plugins.credentials._managed_types.terraform import hcp_terraform
 from awx_plugins.credentials.plugins import (  # noqa: WPS235
     aws,
     azure_rm,
@@ -454,6 +455,47 @@ class YamlEnvFile(BaseEnvFile[dict[str, IniEntryDataType]]):
                 JsonEnvFile('GOOGLE_BACKEND_CREDENTIALS', get_gce_creds()),
             ],
             id='terraform-gcs',
+        ),
+        pytest.param(
+            hcp_terraform,
+            {
+                'token': 'hcp-token-123',
+            },
+            {
+                'TF_TOKEN': 'hcp-token-123',
+                'TF_HOSTNAME': 'app.terraform.io',
+            },
+            {'TF_TOKEN': HIDDEN_PASSWORD},
+            [],
+            id='hcp-terraform-default-hostname',
+        ),
+        pytest.param(
+            hcp_terraform,
+            {
+                'hostname': 'terraform.example.com',
+                'token': 'hcp-custom-token-456',
+            },
+            {
+                'TF_TOKEN': 'hcp-custom-token-456',
+                'TF_HOSTNAME': 'terraform.example.com',
+            },
+            {'TF_TOKEN': HIDDEN_PASSWORD},
+            [],
+            id='hcp-terraform-custom-hostname',
+        ),
+        pytest.param(
+            hcp_terraform,
+            {
+                'hostname': 'app.terraform.io',
+                'token': 'hcp-explicit-default-789',
+            },
+            {
+                'TF_TOKEN': 'hcp-explicit-default-789',
+                'TF_HOSTNAME': 'app.terraform.io',
+            },
+            {'TF_TOKEN': HIDDEN_PASSWORD},
+            [],
+            id='hcp-terraform-explicit-default-hostname',
         ),
         pytest.param(
             net,


### PR DESCRIPTION
The plugins in the hashicorp.terraform collection requires a token to authenticate with TFE/C. When running playbooks leveraging these modules on AAP, this token either needs to be set in the playbook/tasks or a custom credential type needs to be created that injects the token, via the env variable TF_TOKEN. This should be a built-in credential type in Controller for a better UX. There's a credential type already in AAP for Terraform. But that only deals with the backend configuration section which is not valid for TFE/C. 

This PR adds support for the HCP Credential.

https://issues.redhat.com/browse/AAP-57221