### PR TITLE
Update `azure_keyvault_backend` to turn `ServiceRequestError` into a `RuntimeError`

### DIFF
--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -19,6 +19,7 @@ from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS4
 )
 
 from azure.core.credentials import TokenCredential
+from azure.core.exceptions import ServiceRequestError
 from azure.identity import (
     ClientSecretCredential,
     CredentialUnavailableError,
@@ -157,6 +158,10 @@ def azure_keyvault_backend(  # noqa: WPS211
             'feature is unavailable. Please provide the full Client ID, '
             'Client Secret, and Tenant ID or run the software on an Azure VM.',
         ) from secret_lookup_err
+    except ServiceRequestError as request_err:
+        raise RuntimeError(
+            f'Failed to connect to Azure Key Vault: {request_err}',
+        ) from request_err
     return keyvault_secret.value
 
 

--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -164,7 +164,8 @@ def azure_keyvault_backend(  # noqa: WPS211
         ) from request_err
     except _az_exc.AzureError as catchall_azure_error:
         raise RuntimeError(
-            f'Error retrieving secret from Azure Key Vault: {catchall_azure_error}',
+            'Error retrieving secret from Azure Key Vault: '
+            f'{catchall_azure_error}',
         ) from catchall_azure_error
     return keyvault_secret.value
 

--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -19,7 +19,7 @@ from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS4
 )
 
 from azure.core.credentials import TokenCredential
-from azure.core.exceptions import ServiceRequestError
+from azure.core.exceptions import AzureError, ServiceRequestError
 from azure.identity import (
     ClientSecretCredential,
     CredentialUnavailableError,
@@ -162,6 +162,10 @@ def azure_keyvault_backend(  # noqa: WPS211
         raise RuntimeError(
             f'Failed to connect to Azure Key Vault: {request_err}',
         ) from request_err
+    except AzureError as error:
+        raise RuntimeError(
+            f'Error retrieving secret from Azure Key Vault: {error}',
+        )
     return keyvault_secret.value
 
 

--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -18,8 +18,8 @@ from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS4
     gettext_noop as _,
 )
 
+from azure.core import exceptions as _az_exc
 from azure.core.credentials import TokenCredential
-from azure.core.exceptions import AzureError, ServiceRequestError
 from azure.identity import (
     ClientSecretCredential,
     CredentialUnavailableError,
@@ -158,14 +158,14 @@ def azure_keyvault_backend(  # noqa: WPS211
             'feature is unavailable. Please provide the full Client ID, '
             'Client Secret, and Tenant ID or run the software on an Azure VM.',
         ) from secret_lookup_err
-    except ServiceRequestError as request_err:
+    except _az_exc.ServiceRequestError as request_err:
         raise RuntimeError(
             f'Failed to connect to Azure Key Vault: {request_err}',
         ) from request_err
-    except AzureError as error:
+    except _az_exc.AzureError as catchall_azure_error:
         raise RuntimeError(
-            f'Error retrieving secret from Azure Key Vault: {error}',
-        )
+            f'Error retrieving secret from Azure Key Vault: {catchall_azure_error}',
+        ) from catchall_azure_error
     return keyvault_secret.value
 
 

--- a/tests/azure_kv_test.py
+++ b/tests/azure_kv_test.py
@@ -37,13 +37,13 @@ def test_azure_kv_invalid_env(
     simulate the expected CredentialUnavailableError.
     """
     mock_client = mocker.Mock()
+    mock_client = mocker.patch.object(azure_kv, 'SecretClient')
     mock_client.return_value.get_secret.side_effect = (
         CredentialUnavailableError(
             message='ManagedIdentityCredential authentication unavailable.',
         )
     )
     monkeypatch.setattr(azure_kv, 'SecretClient', mock_client)
-
     error_msg = (
         'You are not operating on an Azure VM, so the Managed Identity '
         'feature is unavailable. Please provide the full Client ID, '
@@ -55,8 +55,24 @@ def test_azure_kv_invalid_env(
         match=error_msg,
     ):
         azure_kv.azure_keyvault_backend(
-            url='https://test.vault.azure.net',
+            url='https://keyvault.test',
             client='',
+            secret='client-secret',
+            tenant='tenant-id',
+            secret_field='secret',
+            secret_version='',
+        )
+
+
+def test_azure_kv_dns_error() -> None:
+    """Test DNS resolution error is converted to RuntimeError."""
+    with pytest.raises(
+        RuntimeError,
+        match='Failed to connect to Azure Key Vault',
+    ):
+        azure_kv.azure_keyvault_backend(
+            url='https://keyvault.test',
+            client='client-id',
             secret='client-secret',
             tenant='tenant-id',
             secret_field='secret',
@@ -90,7 +106,7 @@ def test_azure_kv_valid_auth(
     )
 
     keyvault_secret = azure_kv.azure_keyvault_backend(
-        url='https://test.vault.azure.net',
+        url='https://keyvault.test',
         client=client,
         secret=secret,
         tenant=tenant,

--- a/tests/azure_kv_test.py
+++ b/tests/azure_kv_test.py
@@ -3,6 +3,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
+from azure.core.exceptions import AzureError
 from azure.identity import CredentialUnavailableError
 from azure.keyvault.secrets import (
     KeyVaultSecret,
@@ -69,6 +70,32 @@ def test_azure_kv_dns_error() -> None:
     with pytest.raises(
         RuntimeError,
         match='Failed to connect to Azure Key Vault',
+    ):
+        azure_kv.azure_keyvault_backend(
+            url='https://keyvault.test',
+            client='client-id',
+            secret='client-secret',
+            tenant='tenant-id',
+            secret_field='secret',
+            secret_version='',
+        )
+
+
+def test_azure_kv_generic_azure_error(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test generic AzureError is converted to RuntimeError."""
+    mock_client = mocker.Mock()
+    mock_client = mocker.patch.object(azure_kv, 'SecretClient')
+    mock_client.return_value.get_secret.side_effect = AzureError(
+        message='Secret not found or access denied',
+    )
+    monkeypatch.setattr(azure_kv, 'SecretClient', mock_client)
+
+    with pytest.raises(
+        RuntimeError,
+        match='Error retrieving secret from Azure Key Vault',
     ):
         azure_kv.azure_keyvault_backend(
             url='https://keyvault.test',

--- a/tests/azure_kv_test.py
+++ b/tests/azure_kv_test.py
@@ -27,7 +27,6 @@ class _FakeSecretClient(SecretClient):
 
 def test_azure_kv_invalid_env(
     mocker: MockerFixture,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test running outside of Azure raises error.
 
@@ -37,14 +36,13 @@ def test_azure_kv_invalid_env(
     a DNS error before the credential check, so we mock SecretClient to
     simulate the expected CredentialUnavailableError.
     """
-    mock_client = mocker.Mock()
-    mock_client = mocker.patch.object(azure_kv, 'SecretClient')
+    mock_client = mocker.patch.object(azure_kv, 'SecretClient', autospec=True)
     mock_client.return_value.get_secret.side_effect = (
         CredentialUnavailableError(
             message='ManagedIdentityCredential authentication unavailable.',
         )
     )
-    monkeypatch.setattr(azure_kv, 'SecretClient', mock_client)
+
     error_msg = (
         'You are not operating on an Azure VM, so the Managed Identity '
         'feature is unavailable. Please provide the full Client ID, '
@@ -69,7 +67,7 @@ def test_azure_kv_dns_error() -> None:
     """Test DNS resolution error is converted to RuntimeError."""
     with pytest.raises(
         RuntimeError,
-        match='Failed to connect to Azure Key Vault',
+        match=r'^Failed to connect to Azure Key Vault: .',
     ):
         azure_kv.azure_keyvault_backend(
             url='https://keyvault.test',
@@ -83,19 +81,16 @@ def test_azure_kv_dns_error() -> None:
 
 def test_azure_kv_generic_azure_error(
     mocker: MockerFixture,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Test generic AzureError is converted to RuntimeError."""
-    mock_client = mocker.Mock()
-    mock_client = mocker.patch.object(azure_kv, 'SecretClient')
+    mock_client = mocker.patch.object(azure_kv, 'SecretClient', autospec=True)
     mock_client.return_value.get_secret.side_effect = AzureError(
         message='Secret not found or access denied',
     )
-    monkeypatch.setattr(azure_kv, 'SecretClient', mock_client)
 
     with pytest.raises(
         RuntimeError,
-        match='Error retrieving secret from Azure Key Vault',
+        match=r'^Error retrieving secret from Azure Key Vault: .',
     ):
         azure_kv.azure_keyvault_backend(
             url='https://keyvault.test',


### PR DESCRIPTION
Closes: #146 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure Key Vault error handling: connectivity/DNS failures and generic Azure errors are now surfaced as clearer runtime errors with descriptive messages to aid troubleshooting.

* **Tests**
  * Added and updated tests covering DNS/connection failure and generic Azure error conversion, refined existing tests for key vault access, and updated test endpoints to align with the new error behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->