### PR TITLE
🧪 Make `flake8-logging-format` conditional

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -379,6 +379,11 @@ jobs:
         - spellcheck-docs
         xfail:
         - false
+        include:
+        - python-version: 3.14
+          runner-vm-os: ubuntu-latest
+          toxenv: pre-commit
+          xfail: false
       fail-fast: false
 
     uses: tox-dev/workflow/.github/workflows/reusable-tox.yml@88781f74da62948ad3b87b803c95a6ad60c57028  # yamllint disable-line rule:line-length

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -177,8 +177,15 @@ repos:
     - flake8-docstrings ~= 1.7.0
     - flake8-length ~= 0.3.1
     - flake8-logging ~= 1.6.0
-    - flake8-logging-format ~= 2024.24.12
+    # NOTE: `flake8-logging-format` hasn't had updates since 2024 and
+    # NOTE: thus gained an unresolved incompatibility with Python 3.14.
+    - flake8-logging-format ~= 2024.24.12; python_version < "3.14"
     - flake8-pytest-style ~= 2.0.0
+    # NOTE: `setuptools` provides `pkg_resources` needed by
+    # NOTE: `flake8-logging-format`. `setuptools` stopped being bundled
+    # NOTE: in CPython starting Python 3.12. The latest version of
+    # NOTE: `setuptools` that's a part of Python 3.11.14 is v79.0.1.
+    - setuptools < 81; python_version >= "3.12" and python_version < "3.14"
     - wemake-python-styleguide ~= 1.1.0
     language_version: python3
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tool configuration to apply conditional dependency pins for specific Python version ranges and added explanatory compatibility notes.
  * Kept existing hook structure and other tool settings while adjusting only the relevant constraint lines.
* **Tests / CI**
  * Extended the lint job matrix to include the newest Python runner configuration so linting runs under the additional Python version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->