### PR TITLE
🧪💅 Re-enable banned API checks getting rid of the `unittest` imports

### DIFF
--- a/.pylintrc.toml
+++ b/.pylintrc.toml
@@ -357,7 +357,11 @@ single-line-if-stmt = false
 # allow-wildcard-with-all =
 
 # Deprecated modules which should not be used, separated by a comma.
-# deprecated-modules =
+deprecated-modules = [
+  "awx",
+  "django",
+  "unittest",
+]
 
 # Output a graph (.gv or any supported image format) of external dependencies to
 # the given file (report RP0402 must not be disabled).
@@ -382,8 +386,15 @@ known-third-party = [
 
 # Couples of modules and preferred modules, separated by a comma.
 preferred-modules = [
-  "awx:awx_plugins.interfaces",
-  "django:awx_plugins.interfaces",
+  # NOTE(webknjaz): The following entries are commented out in favor of the
+  # NOTE(webknjaz): `deprecated-modules` setting due to this rule following
+  # NOTE(webknjaz): imports and picking up the forbidden ones from the
+  # NOTE(webknjaz): `awx_plugins.interfaces` project that still has some. We
+  # NOTE(webknjaz): should be able to uncomment them once they are removed from
+  # NOTE(webknjaz): there and the platform components (`awx_plugins.*` modules)
+  # NOTE(webknjaz): are completely decoupled from `awx` and `django`.
+  # "awx:awx_plugins.interfaces",
+  # "django:awx_plugins.interfaces",
   "unittest:pytest",
 ]
 
@@ -439,7 +450,6 @@ disable = [
   "no-member",
   "no-self-use",
   "pointless-string-statement",
-  "preferred-module",
   "raise-missing-from",
   "relative-beyond-top-level",
   "singleton-comparison",

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -110,6 +110,23 @@ task-tags = [
 [lint.flake8-pytest-style]
 parametrize-values-type = "tuple"
 
+[lint.flake8-tidy-imports.banned-api]
+"awx".msg = """
+Use `awx_plugins.interfaces._temporary_private_api` instead.
+Best design a public API that does not depend on AWX, though.
+"""
+"django".msg = """
+Use `awx_plugins.interfaces._temporary_private_django_api` instead.
+Best get rid of the indirect dependency on Django, though.
+"""
+"unittest".msg = """
+Use `pytest` instead. For mocking and spying, inject the `mocker` fixture \
+from the already-integrated `pytest-mock` plugin into your tests instead.
+`pytest` also has a built-in `monkeypatch` fixture that can be used in \
+simple cases or combined with `mocker`.
+The existing usage pattern can be found in the existing tests.
+"""
+
 [lint.flake8-quotes]
 inline-quotes = "single"
 

--- a/tests/azure_kv_test.py
+++ b/tests/azure_kv_test.py
@@ -1,8 +1,7 @@
 """Tests Azure Key Vault credential plugin."""
 
-from unittest.mock import Mock
-
 import pytest
+from pytest_mock import MockerFixture
 
 from azure.identity import CredentialUnavailableError
 from azure.keyvault.secrets import (
@@ -25,7 +24,10 @@ class _FakeSecretClient(SecretClient):
         return KeyVaultSecret(properties=props, value='test-secret')
 
 
-def test_azure_kv_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_azure_kv_invalid_env(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Test running outside of Azure raises error.
 
     When credentials are incomplete (e.g., empty client ID), the code falls
@@ -34,7 +36,7 @@ def test_azure_kv_invalid_env(monkeypatch: pytest.MonkeyPatch) -> None:
     a DNS error before the credential check, so we mock SecretClient to
     simulate the expected CredentialUnavailableError.
     """
-    mock_client = Mock()
+    mock_client = mocker.Mock()
     mock_client.return_value.get_secret.side_effect = (
         CredentialUnavailableError(
             message='ManagedIdentityCredential authentication unavailable.',

--- a/tests/credential_plugins_test.py
+++ b/tests/credential_plugins_test.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 from pytest_mock import MockerFixture
 
@@ -30,7 +28,7 @@ def test_hashivault_approle_auth() -> None:
     assert res == expected_res
 
 
-def test_hashivault_kubernetes_auth() -> None:
+def test_hashivault_kubernetes_auth(mocker: MockerFixture) -> None:
     kwargs = {
         'kubernetes_role': 'the_kubernetes_role',
     }
@@ -38,15 +36,15 @@ def test_hashivault_kubernetes_auth() -> None:
         'role': 'the_kubernetes_role',
         'jwt': 'the_jwt',
     }
-    with mock.patch('pathlib.Path') as path_mock:
-        mock.mock_open(path_mock.return_value.open, read_data='the_jwt')
-        res = hashivault.kubernetes_auth(  # type: ignore[no-untyped-call]
-            **kwargs,
-        )
-        path_mock.assert_called_with(
-            '/var/run/secrets/kubernetes.io/serviceaccount/token',
-        )
-        assert res == expected_res
+    path_mock = mocker.patch('pathlib.Path')
+    path_mock.return_value.open = mocker.mock_open(read_data='the_jwt')
+    res = hashivault.kubernetes_auth(  # type: ignore[no-untyped-call]
+        **kwargs,
+    )
+    path_mock.assert_called_with(
+        '/var/run/secrets/kubernetes.io/serviceaccount/token',
+    )
+    assert res == expected_res
 
 
 def test_hashivault_client_cert_auth_explicit_role() -> None:
@@ -88,42 +86,42 @@ def test_hashivault_handle_auth_token() -> None:
     assert token == kwargs['token']
 
 
-def test_hashivault_handle_auth_approle() -> None:
+def test_hashivault_handle_auth_approle(mocker: MockerFixture) -> None:
     kwargs = {
         'role_id': 'the_role_id',
         'secret_id': 'the_secret_id',
     }
-    with mock.patch.object(hashivault, 'method_auth') as method_mock:
-        method_mock.return_value = 'the_token'
-        token = hashivault.handle_auth(  # type: ignore[no-untyped-call]
-            **kwargs,
-        )
-        method_mock.assert_called_with(**kwargs, auth_param=kwargs)
-        assert token == 'the_token'
+    method_mock = mocker.patch.object(hashivault, 'method_auth')
+    method_mock.return_value = 'the_token'
+    token = hashivault.handle_auth(  # type: ignore[no-untyped-call]
+        **kwargs,
+    )
+    method_mock.assert_called_with(**kwargs, auth_param=kwargs)
+    assert token == 'the_token'
 
 
-def test_hashivault_handle_auth_kubernetes() -> None:
+def test_hashivault_handle_auth_kubernetes(mocker: MockerFixture) -> None:
     kwargs = {
         'kubernetes_role': 'the_kubernetes_role',
     }
-    with mock.patch.object(hashivault, 'method_auth') as method_mock:
-        with mock.patch('pathlib.Path') as path_mock:
-            mock.mock_open(path_mock.return_value.open, read_data='the_jwt')
-            method_mock.return_value = 'the_token'
-            token = hashivault.handle_auth(  # type: ignore[no-untyped-call]
-                **kwargs,
-            )
-            method_mock.assert_called_with(
-                **kwargs,
-                auth_param={
-                    'role': 'the_kubernetes_role',
-                    'jwt': 'the_jwt',
-                },
-            )
-            assert token == 'the_token'
+    method_mock = mocker.patch.object(hashivault, 'method_auth')
+    path_mock = mocker.patch('pathlib.Path')
+    path_mock.return_value.open = mocker.mock_open(read_data='the_jwt')
+    method_mock.return_value = 'the_token'
+    token = hashivault.handle_auth(  # type: ignore[no-untyped-call]
+        **kwargs,
+    )
+    method_mock.assert_called_with(
+        **kwargs,
+        auth_param={
+            'role': 'the_kubernetes_role',
+            'jwt': 'the_jwt',
+        },
+    )
+    assert token == 'the_token'
 
 
-def test_hashivault_handle_auth_client_cert() -> None:
+def test_hashivault_handle_auth_client_cert(mocker: MockerFixture) -> None:
     kwargs = {
         'client_cert_public': 'foo',
         'client_cert_private': 'bar',
@@ -132,13 +130,13 @@ def test_hashivault_handle_auth_client_cert() -> None:
     auth_params = {
         'name': 'test-cert-1',
     }
-    with mock.patch.object(hashivault, 'method_auth') as method_mock:
-        method_mock.return_value = 'the_token'
-        token = hashivault.handle_auth(  # type: ignore[no-untyped-call]
-            **kwargs,
-        )
-        method_mock.assert_called_with(**kwargs, auth_param=auth_params)
-        assert token == 'the_token'
+    method_mock = mocker.patch.object(hashivault, 'method_auth')
+    method_mock.return_value = 'the_token'
+    token = hashivault.handle_auth(  # type: ignore[no-untyped-call]
+        **kwargs,
+    )
+    method_mock.assert_called_with(**kwargs, auth_param=auth_params)
+    assert token == 'the_token'
 
 
 def test_hashivault_handle_auth_not_enough_args() -> None:


### PR DESCRIPTION
This patch switches from importing `unittest.mock` to using `pytest-mock` — a native integration of mocking and spying on invocation that is meant to be used in `pytest` ecosystem instead of stdlib directly.

It also fixes up the `pylint` configuration, re-enabling the `preferred-modules` pylint rule, which required moving `awx` and `django` modules to the `deprecated-modules` setting due to `preferred-modules` getting triggered on indirect imports in external projects.

And the last touch is enabling a similar rule in Ruff that is able to show nicer recommendations to contributors tripping over this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to enforce consistent import styles and preferred module patterns across the codebase.
  * Migrated test infrastructure to use modern testing frameworks for improved reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->