### PR TITLE
Add new credential types to support workload identity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,8 @@ name = "Ansible maintainers and contributors"
 conjur = "awx_plugins.credentials.conjur:conjur_plugin"
 hashivault_kv = "awx_plugins.credentials.hashivault:hashivault_kv_plugin"
 hashivault_ssh = "awx_plugins.credentials.hashivault:hashivault_ssh_plugin"
+hashivault-kv-oidc = "awx_plugins.credentials.hashivault:hashivault_kv_oidc_plugin"
+hashivault-ssh-oidc = "awx_plugins.credentials.hashivault:hashivault_ssh_oidc_plugin"
 azure_kv = "awx_plugins.credentials.azure_kv:azure_keyvault_plugin"
 aim = "awx_plugins.credentials.aim:aim_plugin"
 centrify_vault_kv = "awx_plugins.credentials.centrify_vault:centrify_plugin"
@@ -146,6 +148,14 @@ credentials-hashivault-kv = [
   "requests",
 ]
 credentials-hashivault-ssh = [
+  "awx_plugins.interfaces",
+  "requests",
+]
+credentials-hashivault-kv-oidc = [
+  "awx_plugins.interfaces",
+  "requests",
+]
+credentials-hashivault-ssh-oidc = [
   "awx_plugins.interfaces",
   "requests",
 ]

--- a/src/awx_plugins/credentials/_types.py
+++ b/src/awx_plugins/credentials/_types.py
@@ -15,6 +15,7 @@ class FieldDict(_t.TypedDict):
     help_text: _t.NotRequired[str]
     default: _t.NotRequired[str | bool]
     choices: _t.NotRequired[list[str]]
+    internal: _t.NotRequired[bool]
 
 
 class MetadataDict(_t.TypedDict):

--- a/src/awx_plugins/credentials/hashivault.py
+++ b/src/awx_plugins/credentials/hashivault.py
@@ -1,7 +1,6 @@
 # FIXME: the following violations must be addressed gradually and unignored
 # mypy: disable-error-code="arg-type, no-untyped-call, no-untyped-def"
 
-import copy
 import os
 import pathlib
 import time
@@ -13,249 +12,394 @@ from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS4
 
 import requests
 
+from . import _types
 from .plugin import CertFiles, CredentialPlugin, raise_for_status
 
 
-base_inputs = {
+# Base input fields
+url_field: _types.FieldDict = {
+    'id': 'url',
+    'label': _('Server URL'),
+    'type': 'string',
+    'format': 'url',
+    'help_text': _('The URL to the HashiCorp Vault'),
+}
+
+token_field: _types.FieldDict = {
+    'id': 'token',
+    'label': _('Token'),
+    'type': 'string',
+    'secret': True,
+    'help_text': _(
+        'The access token used to authenticate to the Vault server',
+    ),
+}
+
+cacert_field: _types.FieldDict = {
+    'id': 'cacert',
+    'label': _('CA Certificate'),
+    'type': 'string',
+    'multiline': True,
+    'help_text': _(
+        'The CA certificate used to verify the SSL certificate of '
+        'the Vault server',
+    ),
+}
+
+role_id_field: _types.FieldDict = {
+    'id': 'role_id',
+    'label': _('AppRole role_id'),
+    'type': 'string',
+    'multiline': False,
+    'help_text': _('The Role ID for AppRole Authentication'),
+}
+
+secret_id_field: _types.FieldDict = {
+    'id': 'secret_id',
+    'label': _('AppRole secret_id'),
+    'type': 'string',
+    'multiline': False,
+    'secret': True,
+    'help_text': _('The Secret ID for AppRole Authentication'),
+}
+
+client_cert_public_field: _types.FieldDict = {
+    'id': 'client_cert_public',
+    'label': _('Client Certificate'),
+    'type': 'string',
+    'multiline': True,
+    'help_text': _(
+        'The PEM-encoded client certificate used for TLS client '
+        'authentication. This should include the certificate and any '
+        'intermediate certificates.',
+    ),
+}
+
+client_cert_private_field: _types.FieldDict = {
+    'id': 'client_cert_private',
+    'label': _('Client Certificate Key'),
+    'type': 'string',
+    'multiline': True,
+    'secret': True,
+    'help_text': _(
+        'The certificate private key used for TLS client authentication.',
+    ),
+}
+
+client_cert_role_field: _types.FieldDict = {
+    'id': 'client_cert_role',
+    'label': _('TLS Authentication Role'),
+    'type': 'string',
+    'multiline': False,
+    'help_text': _(
+        'The role configured in Hashicorp Vault for TLS client '
+        'authentication. If not provided, Hashicorp Vault may assign '
+        'roles based on the certificate used.',
+    ),
+}
+
+namespace_field: _types.FieldDict = {
+    'id': 'namespace',
+    'label': _('Namespace name (Vault Enterprise only)'),
+    'type': 'string',
+    'multiline': False,
+    'help_text': _(
+        'Name of the namespace to use when authenticate and retrieve secrets',
+    ),
+}
+
+kubernetes_role_field: _types.FieldDict = {
+    'id': 'kubernetes_role',
+    'label': _('Kubernetes role'),
+    'type': 'string',
+    'multiline': False,
+    'help_text': _(
+        'The Role for Kubernetes Authentication. This is the named '
+        'role, configured in Vault server, for AWX pod auth policies. '
+        'see https://www.vaultproject.io/docs/auth/kubernetes'
+        '#configuration',
+    ),
+}
+
+username_field: _types.FieldDict = {
+    'id': 'username',
+    'label': _('Username'),
+    'type': 'string',
+    'secret': False,
+    'help_text': _('Username for user authentication.'),
+}
+
+password_field: _types.FieldDict = {
+    'id': 'password',
+    'label': _('Password'),
+    'type': 'string',
+    'secret': True,
+    'help_text': _('Password for user authentication.'),
+}
+
+default_auth_path_field: _types.FieldDict = {
+    'id': 'default_auth_path',
+    'label': _('Path to Auth'),
+    'type': 'string',
+    'multiline': False,
+    'default': 'approle',
+    'help_text': _(
+        "The Authentication path to use if one isn't provided in the "
+        'metadata when linking to an input field. '
+        "Defaults to 'approle'",
+    ),
+}
+
+# OIDC-specific fields
+jwt_auth_path_field: _types.FieldDict = {
+    'id': 'default_auth_path',
+    'label': _('Path to Auth'),
+    'type': 'string',
+    'multiline': False,
+    'default': 'jwt',
+    'help_text': _(
+        'The path where the JWT authentication method is mounted. '
+        "Defaults to 'jwt'.",
+    ),
+}
+
+jwt_role_field: _types.FieldDict = {
+    'id': 'jwt_role',
+    'label': _('JWT Role'),
+    'type': 'string',
+    'multiline': False,
+    'help_text': _(
+        'The name of the Vault role configured for JWT authentication. '
+        'This role defines what policies and secrets the authenticated '
+        'job can access. Example: controller-automation, aap-production-jobs. '
+        'This must match a role created in Vault at auth/jwt/role/<role-name>.',
+    ),
+}
+
+jwt_audience_field: _types.FieldDict = {
+    'id': 'jwt_aud',
+    'label': _('JWT Audience'),
+    'type': 'string',
+    'multiline': False,
+    'help_text': _(
+        'Identifies this Vault instance as the intended recipient of JWTs. '
+        'This value must match the bound_audiences configuration in your '
+        'Vault JWT auth method. Examples: hashicorp-vault-prod-01, '
+        'https://vault.example.com, or vault-production.',
+    ),
+}
+
+# Base metadata fields
+secret_path_metadata: _types.MetadataDict = {
+    'id': 'secret_path',
+    'label': _('Path to Secret'),
+    'type': 'string',
+    'help_text': _(
+        (
+            'The path to the secret stored in the secret backend e.g, '
+            '/some/secret/. It is recommended that you use the secret '
+            'backend field to identify the storage backend and to use '
+            'this field for locating a specific secret within that '
+            'store. However, if you prefer to fully identify both the '
+            'secret backend and one of its secrets using only this '
+            'field, join their locations into a single path without '
+            'any additional separators, '
+            'e.g, /location/of/backend/some/secret.'
+        ),
+    ),
+}
+
+auth_path_metadata: _types.MetadataDict = {
+    'id': 'auth_path',
+    'label': _('Path to Auth'),
+    'type': 'string',
+    'multiline': False,
+    'help_text': _(
+        'The path where the Authentication method is mounted e.g, approle',
+    ),
+}
+
+# KV-specific fields and metadata
+api_version_field: _types.FieldDict = {
+    'id': 'api_version',
+    'label': _('API Version'),
+    'type': 'string',
+    'choices': ['v1', 'v2'],
+    'help_text': _(
+        'API v1 is for static key/value lookups.  API v2 is for versioned '
+        'key/value lookups.',
+    ),
+    'default': 'v1',
+}
+
+secret_backend_metadata: _types.MetadataDict = {
+    'id': 'secret_backend',
+    'label': _('Name of Secret Backend'),
+    'type': 'string',
+    'help_text': _(
+        'The name of the kv secret backend (if left empty, the first '
+        'segment of the secret path will be used).',
+    ),
+}
+
+secret_key_metadata: _types.MetadataDict = {
+    'id': 'secret_key',
+    'label': _('Key Name'),
+    'type': 'string',
+    'help_text': _('The name of the key to look up in the secret.'),
+}
+
+secret_version_metadata: _types.MetadataDict = {
+    'id': 'secret_version',
+    'label': _('Secret Version (v2 only)'),
+    'type': 'string',
+    'help_text': _(
+        'Used to specify a specific secret version (if left empty, '
+        'the latest version will be used).',
+    ),
+}
+
+# SSH-specific metadata
+public_key_metadata: _types.MetadataDict = {
+    'id': 'public_key',
+    'label': _('Unsigned Public Key'),
+    'type': 'string',
+    'multiline': True,
+}
+
+role_metadata: _types.MetadataDict = {
+    'id': 'role',
+    'label': _('Role Name'),
+    'type': 'string',
+    'help_text': _('The name of the role used to sign.'),
+}
+
+valid_principals_metadata: _types.MetadataDict = {
+    'id': 'valid_principals',
+    'label': _('Valid Principals'),
+    'type': 'string',
+    'help_text': _(
+        'Valid principals (either usernames or hostnames) that the '
+        'certificate should be signed for.',
+    ),
+}
+
+
+hashi_kv_inputs: _types.PluginInputs = {
     'fields': [
-        {
-            'id': 'url',
-            'label': _('Server URL'),
-            'type': 'string',
-            'format': 'url',
-            'help_text': _('The URL to the HashiCorp Vault'),
-        },
-        {
-            'id': 'token',
-            'label': _('Token'),
-            'type': 'string',
-            'secret': True,
-            'help_text': _(
-                'The access token used to authenticate to the Vault server',
-            ),
-        },
-        {
-            'id': 'cacert',
-            'label': _('CA Certificate'),
-            'type': 'string',
-            'multiline': True,
-            'help_text': _(
-                'The CA certificate used to verify the SSL certificate of '
-                'the Vault server',
-            ),
-        },
-        {
-            'id': 'role_id',
-            'label': _('AppRole role_id'),
-            'type': 'string',
-            'multiline': False,
-            'help_text': _('The Role ID for AppRole Authentication'),
-        },
-        {
-            'id': 'secret_id',
-            'label': _('AppRole secret_id'),
-            'type': 'string',
-            'multiline': False,
-            'secret': True,
-            'help_text': _('The Secret ID for AppRole Authentication'),
-        },
-        {
-            'id': 'client_cert_public',
-            'label': _('Client Certificate'),
-            'type': 'string',
-            'multiline': True,
-            'help_text': _(
-                'The PEM-encoded client certificate used for TLS client '
-                'authentication. This should include the certificate and any '
-                'intermediate certififcates.',
-            ),
-        },
-        {
-            'id': 'client_cert_private',
-            'label': _('Client Certificate Key'),
-            'type': 'string',
-            'multiline': True,
-            'secret': True,
-            'help_text': _(
-                'The certificate private key used for TLS client '
-                'authentication.',
-            ),
-        },
-        {
-            'id': 'client_cert_role',
-            'label': _('TLS Authentication Role'),
-            'type': 'string',
-            'multiline': False,
-            'help_text': _(
-                'The role configured in Hashicorp Vault for TLS client '
-                'authentication. If not provided, Hashicorp Vault may assign '
-                'roles based on the certificate used.',
-            ),
-        },
-        {
-            'id': 'namespace',
-            'label': _('Namespace name (Vault Enterprise only)'),
-            'type': 'string',
-            'multiline': False,
-            'help_text': _(
-                'Name of the namespace to use when authenticate and retrieve '
-                'secrets',
-            ),
-        },
-        {
-            'id': 'kubernetes_role',
-            'label': _('Kubernetes role'),
-            'type': 'string',
-            'multiline': False,
-            'help_text': _(
-                'The Role for Kubernetes Authentication. This is the named '
-                'role, configured in Vault server, for AWX pod auth policies. '
-                'see https://www.vaultproject.io/docs/auth/kubernetes'
-                '#configuration',
-            ),
-        },
-        {
-            'id': 'username',
-            'label': _('Username'),
-            'type': 'string',
-            'secret': False,
-            'help_text': _('Username for user authentication.'),
-        },
-        {
-            'id': 'password',
-            'label': _('Password'),
-            'type': 'string',
-            'secret': True,
-            'help_text': _('Password for user authentication.'),
-        },
-        {
-            'id': 'default_auth_path',
-            'label': _('Path to Auth'),
-            'type': 'string',
-            'multiline': False,
-            'default': 'approle',
-            'help_text': _(
-                "The Authentication path to use if one isn't provided in the "
-                'metadata when linking to an input field. '
-                "Defaults to 'approle'",
-            ),
-        },
+        url_field,
+        token_field,
+        cacert_field,
+        role_id_field,
+        secret_id_field,
+        client_cert_public_field,
+        client_cert_private_field,
+        client_cert_role_field,
+        namespace_field,
+        kubernetes_role_field,
+        username_field,
+        password_field,
+        default_auth_path_field,
+        api_version_field,
     ],
     'metadata': [
-        {
-            'id': 'secret_path',
-            'label': _('Path to Secret'),
-            'type': 'string',
-            'help_text': _(
-                (
-                    'The path to the secret stored in the secret backend e.g, '
-                    '/some/secret/. It is recommended that you use the secret '
-                    'backend field to identify the storage backend and to use '
-                    'this field for locating a specific secret within that '
-                    'store. However, if you prefer to fully identify both the '
-                    'secret backend and one of its secrets using only this '
-                    'field, join their locations into a single path without '
-                    'any additional separators, '
-                    'e.g, /location/of/backend/some/secret.'
-                ),
-            ),
-        },
-        {
-            'id': 'auth_path',
-            'label': _('Path to Auth'),
-            'type': 'string',
-            'multiline': False,
-            'help_text': _(
-                'The path where the Authentication method is mounted e.g, approle',
-            ),
-        },
+        secret_backend_metadata,
+        secret_path_metadata,
+        auth_path_metadata,
+        secret_key_metadata,
+        secret_version_metadata,
     ],
     'required': [
         'url',
         'secret_path',
+        'api_version',
+        'secret_key',
     ],
 }
 
-hashi_kv_inputs = copy.deepcopy(base_inputs)
-hashi_kv_inputs['fields'].append(  # type: ignore[attr-defined]  # FIXME
-    {
-        'id': 'api_version',
-        'label': _('API Version'),
-        'choices': ['v1', 'v2'],
-        'help_text': _(
-            'API v1 is for static key/value lookups.  API v2 is for versioned '
-            'key/value lookups.',
-        ),
-        'default': 'v1',
-    },
-)
-hashi_kv_inputs['metadata'] = (
-    [  # type: ignore[operator]  # FIXME
-        {
-            'id': 'secret_backend',
-            'label': _('Name of Secret Backend'),
-            'type': 'string',
-            'help_text': _(
-                'The name of the kv secret backend (if left empty, the first '
-                'segment of the secret path will be used).',
-            ),
-        },
-    ]
-    + hashi_kv_inputs['metadata']
-    + [
-        {
-            'id': 'secret_key',
-            'label': _('Key Name'),
-            'type': 'string',
-            'help_text': _('The name of the key to look up in the secret.'),
-        },
-        {
-            'id': 'secret_version',
-            'label': _('Secret Version (v2 only)'),
-            'type': 'string',
-            'help_text': _(
-                'Used to specify a specific secret version (if left empty, '
-                'the latest version will be used).',
-            ),
-        },
-    ]
-)
-hashi_kv_inputs['required'].extend(  # type: ignore[attr-defined]  # FIXME
-    ['api_version', 'secret_key'],
-)
+hashi_kv_oidc_inputs: _types.PluginInputs = {
+    'fields': [
+        url_field,
+        api_version_field,
+        cacert_field,
+        jwt_auth_path_field,
+        jwt_role_field,
+        jwt_audience_field,
+        namespace_field,
+    ],
+    'metadata': [
+        secret_backend_metadata,
+        secret_path_metadata,
+        secret_key_metadata,
+        secret_version_metadata,
+    ],
+    'required': [
+        'url',
+        'api_version',
+        'default_auth_path',
+        'jwt_role',
+        'jwt_aud',
+        'secret_path',
+        'secret_key',
+    ],
+}
 
-hashi_ssh_inputs = copy.deepcopy(base_inputs)
-hashi_ssh_inputs['metadata'] = (
-    [  # type: ignore[operator]  # FIXME
-        {
-            'id': 'public_key',
-            'label': _('Unsigned Public Key'),
-            'type': 'string',
-            'multiline': True,
-        },
-    ]
-    + hashi_ssh_inputs['metadata']
-    + [
-        {
-            'id': 'role',
-            'label': _('Role Name'),
-            'type': 'string',
-            'help_text': _('The name of the role used to sign.'),
-        },
-        {
-            'id': 'valid_principals',
-            'label': _('Valid Principals'),
-            'type': 'string',
-            'help_text': _(
-                'Valid principals (either usernames or hostnames) that the '
-                'certificate should be signed for.',
-            ),
-        },
-    ]
-)
-hashi_ssh_inputs['required'].extend(  # type: ignore[attr-defined]  # FIXME
-    ['public_key', 'role'],
-)
+hashi_ssh_inputs: _types.PluginInputs = {
+    'fields': [
+        url_field,
+        token_field,
+        cacert_field,
+        role_id_field,
+        secret_id_field,
+        client_cert_public_field,
+        client_cert_private_field,
+        client_cert_role_field,
+        namespace_field,
+        kubernetes_role_field,
+        username_field,
+        password_field,
+        default_auth_path_field,
+    ],
+    'metadata': [
+        public_key_metadata,
+        secret_path_metadata,
+        auth_path_metadata,
+        role_metadata,
+        valid_principals_metadata,
+    ],
+    'required': [
+        'url',
+        'secret_path',
+        'public_key',
+        'role',
+    ],
+}
+
+hashi_ssh_oidc_inputs: _types.PluginInputs = {
+    'fields': [
+        url_field,
+        cacert_field,
+        jwt_auth_path_field,
+        jwt_role_field,
+        jwt_audience_field,
+        namespace_field,
+    ],
+    'metadata': [
+        public_key_metadata,
+        secret_path_metadata,
+        role_metadata,
+        valid_principals_metadata,
+    ],
+    'required': [
+        'url',
+        'default_auth_path',
+        'jwt_role',
+        'jwt_aud',
+        'secret_path',
+        'public_key',
+        'role',
+    ],
+}
 
 
 def handle_auth(**kwargs):
@@ -272,6 +416,11 @@ def handle_auth(**kwargs):
         'client_cert_private',
     ):
         token = method_auth(**kwargs, auth_param=client_cert_auth(**kwargs))
+    elif kwargs.get('workload_identity_token'):
+        token = method_auth(
+            **kwargs,
+            auth_param=workload_identity_auth(**kwargs),
+        )
     else:
         raise Exception(
             'Token, Username/Password, AppRole, Kubernetes, or TLS authentication parameters must be set',
@@ -298,6 +447,12 @@ def kubernetes_auth(**kwargs):
 
 def client_cert_auth(**kwargs):
     return {'name': kwargs.get('client_cert_role')}
+
+
+def workload_identity_auth(**kwargs):
+    """JWT representing a workload. Issued by an OIDC entity trusted by Vault."""
+    workload_identity_token = kwargs.get('workload_identity_token')
+    return {'role': kwargs.get('jwt_role'), 'jwt': workload_identity_token}
 
 
 def method_auth(**kwargs):
@@ -473,5 +628,17 @@ hashivault_kv_plugin = CredentialPlugin(
 hashivault_ssh_plugin = CredentialPlugin(
     'HashiCorp Vault Signed SSH',
     inputs=hashi_ssh_inputs,
+    backend=ssh_backend,
+)
+
+hashivault_kv_oidc_plugin = CredentialPlugin(
+    'HashiCorp Vault Secret Lookup (OIDC)',
+    inputs=hashi_kv_oidc_inputs,
+    backend=kv_backend,
+)
+
+hashivault_ssh_oidc_plugin = CredentialPlugin(
+    'HashiCorp Vault Signed SSH (OIDC)',
+    inputs=hashi_ssh_oidc_inputs,
     backend=ssh_backend,
 )

--- a/src/awx_plugins/credentials/hashivault.py
+++ b/src/awx_plugins/credentials/hashivault.py
@@ -310,10 +310,10 @@ hashi_kv_inputs: _types.PluginInputs = {
         secret_version_metadata,
     ],
     'required': [
-        'url',
-        'secret_path',
-        'api_version',
-        'secret_key',
+        url_field['id'],
+        secret_path_metadata['id'],
+        api_version_field['id'],
+        secret_key_metadata['id'],
     ],
 }
 
@@ -334,13 +334,13 @@ hashi_kv_oidc_inputs: _types.PluginInputs = {
         secret_version_metadata,
     ],
     'required': [
-        'url',
-        'api_version',
-        'default_auth_path',
-        'jwt_role',
-        'jwt_aud',
-        'secret_path',
-        'secret_key',
+        url_field['id'],
+        api_version_field['id'],
+        jwt_auth_path_field['id'],
+        jwt_role_field['id'],
+        jwt_audience_field['id'],
+        secret_path_metadata['id'],
+        secret_key_metadata['id'],
     ],
 }
 
@@ -368,10 +368,10 @@ hashi_ssh_inputs: _types.PluginInputs = {
         valid_principals_metadata,
     ],
     'required': [
-        'url',
-        'secret_path',
-        'public_key',
-        'role',
+        url_field['id'],
+        secret_path_metadata['id'],
+        public_key_metadata['id'],
+        role_metadata['id'],
     ],
 }
 
@@ -391,13 +391,13 @@ hashi_ssh_oidc_inputs: _types.PluginInputs = {
         valid_principals_metadata,
     ],
     'required': [
-        'url',
-        'default_auth_path',
-        'jwt_role',
-        'jwt_aud',
-        'secret_path',
-        'public_key',
-        'role',
+        url_field['id'],
+        jwt_auth_path_field['id'],
+        jwt_role_field['id'],
+        jwt_audience_field['id'],
+        secret_path_metadata['id'],
+        public_key_metadata['id'],
+        role_metadata['id'],
     ],
 }
 

--- a/src/awx_plugins/credentials/hashivault.py
+++ b/src/awx_plugins/credentials/hashivault.py
@@ -189,6 +189,18 @@ jwt_audience_field: _types.FieldDict = {
     ),
 }
 
+workload_identity_token_field: _types.FieldDict = {
+    'id': 'workload_identity_token',
+    'label': _('Workload Identity Token'),
+    'type': 'string',
+    'secret': True,
+    'internal': True,
+    'help_text': _(
+        'JWT token for workload identity authentication. '
+        'Automatically populated by the system.',
+    ),
+}
+
 # Base metadata fields
 secret_path_metadata: _types.MetadataDict = {
     'id': 'secret_path',
@@ -326,6 +338,7 @@ hashi_kv_oidc_inputs: _types.PluginInputs = {
         jwt_role_field,
         jwt_audience_field,
         namespace_field,
+        workload_identity_token_field,
     ],
     'metadata': [
         secret_backend_metadata,
@@ -383,6 +396,7 @@ hashi_ssh_oidc_inputs: _types.PluginInputs = {
         jwt_role_field,
         jwt_audience_field,
         namespace_field,
+        workload_identity_token_field,
     ],
     'metadata': [
         public_key_metadata,

--- a/tests/importable_test.py
+++ b/tests/importable_test.py
@@ -47,6 +47,16 @@ credential_plugins = (
     ),
     EntryPointParam(
         'awx_plugins.credentials',
+        'hashivault-kv-oidc',
+        'awx_plugins.credentials.hashivault:hashivault_kv_oidc_plugin',
+    ),
+    EntryPointParam(
+        'awx_plugins.credentials',
+        'hashivault-ssh-oidc',
+        'awx_plugins.credentials.hashivault:hashivault_ssh_oidc_plugin',
+    ),
+    EntryPointParam(
+        'awx_plugins.credentials',
         'azure_kv',
         'awx_plugins.credentials.azure_kv:azure_keyvault_plugin',
     ),

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -181,7 +181,12 @@ def test_hashivault_handle_auth_workload_identity(
         'role': 'the_jwt_role',
         'jwt': 'the_jwt_token',
     }
-    method_mock = mocker.patch.object(hashivault, 'method_auth', autospec=True, return_value='the_token')
+    method_mock = mocker.patch.object(
+        hashivault,
+        'method_auth',
+        autospec=True,
+        return_value='the_token',
+    )
     token = hashivault.handle_auth(**kwargs)  # type: ignore[no-untyped-call]
     method_mock.assert_called_with(**kwargs, auth_param=auth_params)
     assert token == 'the_token'

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -77,6 +77,17 @@ def test_hashivault_userpass_auth() -> None:
     assert res == expected_res
 
 
+def test_hashivault_workload_identity_auth() -> None:
+    """Test ``workload_identity_auth()`` returns the token."""
+    kwargs = {
+        'workload_identity_token': 'the_jwt_token',
+        'jwt_role': 'the_jwt_role',
+    }
+    expected_res = {'role': 'the_jwt_role', 'jwt': 'the_jwt_token'}
+    res = hashivault.workload_identity_auth(**kwargs)  # type: ignore[no-untyped-call]
+    assert res == expected_res
+
+
 def test_hashivault_handle_auth_token() -> None:
     """Test ``handle_auth()`` with token auth returns the token."""
     kwargs = {
@@ -138,6 +149,27 @@ def test_hashivault_handle_auth_client_cert(mocker: MockerFixture) -> None:
     token = hashivault.handle_auth(  # type: ignore[no-untyped-call]
         **kwargs,
     )
+    method_mock.assert_called_with(**kwargs, auth_param=auth_params)
+    assert token == 'the_token'
+
+
+def test_hashivault_handle_auth_workload_identity(
+    mocker: MockerFixture,
+) -> None:
+    """Test handle auth with workload identity auth."""
+    kwargs = {
+        'workload_identity_token': 'the_jwt_token',
+        'jwt_role': 'the_jwt_role',
+        'default_auth_path': 'jwt',
+        'url': 'https://vault.example.com',
+    }
+    auth_params = {
+        'role': 'the_jwt_role',
+        'jwt': 'the_jwt_token',
+    }
+    method_mock = mocker.patch.object(hashivault, 'method_auth')
+    method_mock.return_value = 'the_token'
+    token = hashivault.handle_auth(**kwargs)  # type: ignore[no-untyped-call]
     method_mock.assert_called_with(**kwargs, auth_param=auth_params)
     assert token == 'the_token'
 
@@ -219,6 +251,55 @@ def test_hashivault_handle_auth_not_enough_args() -> None:
                 'valid_principals',
             ],
             id='ssh-metadata',
+        ),
+        pytest.param(
+            hashivault.hashivault_kv_oidc_plugin,
+            'fields',
+            [
+                'url',
+                'api_version',
+                'cacert',
+                'default_auth_path',
+                'jwt_role',
+                'jwt_aud',
+                'namespace',
+            ],
+            id='kv-oidc-fields',
+        ),
+        pytest.param(
+            hashivault.hashivault_kv_oidc_plugin,
+            'metadata',
+            [
+                'secret_backend',
+                'secret_path',
+                'secret_key',
+                'secret_version',
+            ],
+            id='kv-oidc-metadata',
+        ),
+        pytest.param(
+            hashivault.hashivault_ssh_oidc_plugin,
+            'fields',
+            [
+                'url',
+                'cacert',
+                'default_auth_path',
+                'jwt_role',
+                'jwt_aud',
+                'namespace',
+            ],
+            id='ssh-oidc-fields',
+        ),
+        pytest.param(
+            hashivault.hashivault_ssh_oidc_plugin,
+            'metadata',
+            [
+                'public_key',
+                'secret_path',
+                'role',
+                'valid_principals',
+            ],
+            id='ssh-oidc-metadata',
         ),
     ),
 )

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -5,7 +5,7 @@ import typing as _t
 import pytest
 from pytest_mock import MockerFixture
 
-from awx_plugins.credentials import hashivault
+from awx_plugins.credentials import _types, hashivault
 from awx_plugins.credentials.plugin import CredentialPlugin
 
 
@@ -346,13 +346,16 @@ def test_workload_identity_token_field_internal() -> None:
     assert field['secret'] is True
 
 
-def test_workload_identity_token_field_not_req() -> None:
-    """Verify workload_identity_token is not in the required list for OIDC plugins."""
-    for inputs in (
-        hashivault.hashi_kv_oidc_inputs,
-        hashivault.hashi_ssh_oidc_inputs,
-    ):
-        assert 'workload_identity_token' not in inputs['required']
+@pytest.mark.parametrize(
+    'plugin_inputs',
+    (hashivault.hashi_kv_oidc_inputs, hashivault.hashi_ssh_oidc_inputs),
+    ids=('kv-oidc', 'ssh-oidc'),
+)
+def test_workload_identity_token_field_not_req(
+    plugin_inputs: _types.PluginInputs,
+) -> None:
+    """Verify ``workload_identity_token`` is not in the required list for OIDC plugins."""
+    assert 'workload_identity_token' not in plugin_inputs['required']
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -285,6 +285,7 @@ def test_hashivault_handle_auth_not_enough_args() -> None:
                 'jwt_role',
                 'jwt_aud',
                 'namespace',
+                'workload_identity_token',
             ],
             id='kv-oidc-fields',
         ),
@@ -309,6 +310,7 @@ def test_hashivault_handle_auth_not_enough_args() -> None:
                 'jwt_role',
                 'jwt_aud',
                 'namespace',
+                'workload_identity_token',
             ],
             id='ssh-oidc-fields',
         ),
@@ -334,3 +336,54 @@ def test_plugin_input_ids(
     plugin_inputs = plugin.inputs
     actual_ids = [plugin['id'] for plugin in plugin_inputs[field_type]]
     assert actual_ids == expected_ids
+
+
+def test_workload_identity_token_field_is_internal() -> None:
+    """Verify the workload_identity_token field is marked internal."""
+    field = hashivault.workload_identity_token_field
+    assert field['id'] == 'workload_identity_token'
+    assert field['internal'] is True
+    assert field['secret'] is True
+
+
+def test_workload_identity_token_field_not_required() -> None:
+    """Verify workload_identity_token is not in the required list for OIDC plugins."""
+    for inputs in (hashivault.hashi_kv_oidc_inputs, hashivault.hashi_ssh_oidc_inputs):
+        assert 'workload_identity_token' not in inputs['required']
+
+
+@pytest.mark.parametrize(
+    'plugin',
+    (
+        pytest.param(hashivault.hashivault_kv_oidc_plugin, id='kv-oidc'),
+        pytest.param(hashivault.hashivault_ssh_oidc_plugin, id='ssh-oidc'),
+    ),
+)
+def test_oidc_plugin_has_one_internal_field(
+    plugin: CredentialPlugin,
+) -> None:
+    """Verify OIDC plugins have exactly one internal field."""
+    internal_fields = [
+        f for f in plugin.inputs['fields']
+        if f.get('internal')
+    ]
+    assert len(internal_fields) == 1
+    assert internal_fields[0]['id'] == 'workload_identity_token'
+
+
+@pytest.mark.parametrize(
+    'plugin',
+    (
+        pytest.param(hashivault.hashivault_kv_plugin, id='kv'),
+        pytest.param(hashivault.hashivault_ssh_plugin, id='ssh'),
+    ),
+)
+def test_non_oidc_plugins_have_no_internal_fields(
+    plugin: CredentialPlugin,
+) -> None:
+    """Verify non-OIDC plugins have no internal fields."""
+    internal_fields = [
+        f for f in plugin.inputs['fields']
+        if f.get('internal')
+    ]
+    assert internal_fields == []

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -171,7 +171,7 @@ def test_hashivault_handle_auth_workload_identity(
     mocker: MockerFixture,
 ) -> None:
     """Test handle auth with workload identity auth."""
-    kwargs = {
+    workload_id_kwargs = {
         'workload_identity_token': 'the_jwt_token',
         'jwt_role': 'the_jwt_role',
         'default_auth_path': 'jwt',
@@ -181,8 +181,7 @@ def test_hashivault_handle_auth_workload_identity(
         'role': 'the_jwt_role',
         'jwt': 'the_jwt_token',
     }
-    method_mock = mocker.patch.object(hashivault, 'method_auth')
-    method_mock.return_value = 'the_token'
+    method_mock = mocker.patch.object(hashivault, 'method_auth', autospec=True, return_value='the_token')
     token = hashivault.handle_auth(**kwargs)  # type: ignore[no-untyped-call]
     method_mock.assert_called_with(**kwargs, auth_param=auth_params)
     assert token == 'the_token'

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -93,7 +93,8 @@ def test_hashivault_workload_identity_auth(
         'jwt': sentinel_jwt_value,
     }
 
-    computed_jwt_object = hashivault.workload_identity_auth(
+    auth = hashivault.workload_identity_auth
+    computed_jwt_object = auth(  # type: ignore[no-untyped-call]
         workload_identity_token=sentinel_jwt_value,
         jwt_role=sentinel_role_value,
         **arbitrary_kwargs,
@@ -187,8 +188,11 @@ def test_hashivault_handle_auth_workload_identity(
         autospec=True,
         return_value='the_token',
     )
-    token = hashivault.handle_auth(**kwargs)  # type: ignore[no-untyped-call]
-    method_mock.assert_called_with(**kwargs, auth_param=auth_params)
+    token = hashivault.handle_auth(**workload_id_kwargs)  # type: ignore[no-untyped-call]
+    method_mock.assert_called_with(
+        **workload_id_kwargs,
+        auth_param=auth_params,
+    )
     assert token == 'the_token'
 
 

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -338,7 +338,7 @@ def test_plugin_input_ids(
     assert actual_ids == expected_ids
 
 
-def test_workload_identity_token_field_is_internal() -> None:
+def test_workload_identity_token_field_internal() -> None:
     """Verify the workload_identity_token field is marked internal."""
     field = hashivault.workload_identity_token_field
     assert field['id'] == 'workload_identity_token'
@@ -346,9 +346,12 @@ def test_workload_identity_token_field_is_internal() -> None:
     assert field['secret'] is True
 
 
-def test_workload_identity_token_field_not_required() -> None:
+def test_workload_identity_token_field_not_req() -> None:
     """Verify workload_identity_token is not in the required list for OIDC plugins."""
-    for inputs in (hashivault.hashi_kv_oidc_inputs, hashivault.hashi_ssh_oidc_inputs):
+    for inputs in (
+        hashivault.hashi_kv_oidc_inputs,
+        hashivault.hashi_ssh_oidc_inputs,
+    ):
         assert 'workload_identity_token' not in inputs['required']
 
 
@@ -364,8 +367,7 @@ def test_oidc_plugin_has_one_internal_field(
 ) -> None:
     """Verify OIDC plugins have exactly one internal field."""
     internal_fields = [
-        f for f in plugin.inputs['fields']
-        if f.get('internal')
+        field for field in plugin.inputs['fields'] if field.get('internal')
     ]
     assert len(internal_fields) == 1
     assert internal_fields[0]['id'] == 'workload_identity_token'
@@ -383,7 +385,6 @@ def test_non_oidc_plugins_have_no_internal_fields(
 ) -> None:
     """Verify non-OIDC plugins have no internal fields."""
     internal_fields = [
-        f for f in plugin.inputs['fields']
-        if f.get('internal')
+        field for field in plugin.inputs['fields'] if field.get('internal')
     ]
     assert internal_fields == []

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -82,11 +82,16 @@ def test_hashivault_userpass_auth() -> None:
     ({}, {'utter': 'nonsense'}),
     ids=('no-additional-keyword-args', 'with-additional-keyword-arg'),
 )
-def test_hashivault_workload_identity_auth(arbitrary_kwargs: dict[str, str]) -> None:
+def test_hashivault_workload_identity_auth(
+    arbitrary_kwargs: dict[str, str],
+) -> None:
     """Test ``workload_identity_auth()`` returns the token."""
     sentinel_role_value = 'the_jwt_role'
     sentinel_jwt_value = 'the_jwt_token'
-    expected_jwt_object = {'role': sentinel_role_value, 'jwt': sentinel_jwt_value}
+    expected_jwt_object = {
+        'role': sentinel_role_value,
+        'jwt': sentinel_jwt_value,
+    }
 
     computed_jwt_object = hashivault.workload_identity_auth(
         workload_identity_token=sentinel_jwt_value,

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -77,15 +77,24 @@ def test_hashivault_userpass_auth() -> None:
     assert res == expected_res
 
 
-def test_hashivault_workload_identity_auth() -> None:
+@pytest.mark.parametrize(
+    'arbitrary_kwargs',
+    ({}, {'utter': 'nonsense'}),
+    ids=('no-additional-keyword-args', 'with-additional-keyword-arg'),
+)
+def test_hashivault_workload_identity_auth(arbitrary_kwargs: dict[str, str]) -> None:
     """Test ``workload_identity_auth()`` returns the token."""
-    kwargs = {
-        'workload_identity_token': 'the_jwt_token',
-        'jwt_role': 'the_jwt_role',
-    }
-    expected_res = {'role': 'the_jwt_role', 'jwt': 'the_jwt_token'}
-    res = hashivault.workload_identity_auth(**kwargs)  # type: ignore[no-untyped-call]
-    assert res == expected_res
+    sentinel_role_value = 'the_jwt_role'
+    sentinel_jwt_value = 'the_jwt_token'
+    expected_jwt_object = {'role': sentinel_role_value, 'jwt': sentinel_jwt_value}
+
+    computed_jwt_object = hashivault.workload_identity_auth(
+        workload_identity_token=sentinel_jwt_value,
+        jwt_role=sentinel_role_value,
+        **arbitrary_kwargs,
+    )
+
+    assert computed_jwt_object == expected_jwt_object
 
 
 def test_hashivault_handle_auth_token() -> None:


### PR DESCRIPTION
AAP-64507

New credential plugins:
- HashiCorp Vault Secret Lookup (OIDC) - hashivault_kv_oidc_plugin
- HashiCorp Vault Signed SSH (OIDC) - hashivault_ssh_oidc_plugin

New authentication method:
- workload_identity_auth() - Handles JWT-based authentication using workload identity tokens

Refactored field definitions to individual field variables. This makes the definition of the credential types more readable. I also added unit tests.

Needs: https://github.com/ansible/awx-plugins/pull/150 

Screenshots:
<img width="1624" height="756" alt="image" src="https://github.com/user-attachments/assets/a1325ac3-fef5-42a6-bc34-f1e441d7a95c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenID Connect (OIDC) authentication support for HashiCorp Vault credentials.
  * Introduced workload identity (JWT) authentication flow for Vault access.
  * Added OIDC-enabled credential plugin variants for Vault KV and SSH, available as installable plugins.

* **Tests**
  * Added unit tests covering workload identity authentication and OIDC plugin inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->