### PR TITLE
🧪 Bump flake8 plugins to latest in pre-commit

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -447,7 +447,7 @@ jobs:
               fromJSON('["pre-commit", "spellcheck-docs"]'),
               matrix.toxenv
             )
-            && 4
+            && 5
             || 2
           )
         }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,22 +171,22 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies:
-    - flake8-annotations ~= 3.1.1
-    - flake8-comprehensions ~= 3.15.0
+    - flake8-annotations ~= 3.2.0
+    - flake8-comprehensions ~= 3.17.0
     - flake8-cognitive-complexity ~= 0.1.0
     - flake8-docstrings ~= 1.7.0
     - flake8-length ~= 0.3.1
-    - flake8-logging ~= 1.6.0
+    - flake8-logging ~= 1.8.0
     # NOTE: `flake8-logging-format` hasn't had updates since 2024 and
     # NOTE: thus gained an unresolved incompatibility with Python 3.14.
     - flake8-logging-format ~= 2024.24.12; python_version < "3.14"
-    - flake8-pytest-style ~= 2.0.0
+    - flake8-pytest-style ~= 2.2.0
     # NOTE: `setuptools` provides `pkg_resources` needed by
     # NOTE: `flake8-logging-format`. `setuptools` stopped being bundled
     # NOTE: in CPython starting Python 3.12. The latest version of
     # NOTE: `setuptools` that's a part of Python 3.11.14 is v79.0.1.
     - setuptools < 81; python_version >= "3.12" and python_version < "3.14"
-    - wemake-python-styleguide ~= 1.1.0
+    - wemake-python-styleguide ~= 1.5.0
     language_version: python3
 
 - repo: https://github.com/Lucas-C/pre-commit-hooks-lxml.git


### PR DESCRIPTION
Upgrading `flake8-pytest-style` fixes compatibility issues with Python 3.14 in particular.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development tooling and linting configurations (pre-commit hooks and CI lint/test timeouts) to keep quality checks current. No changes to application behavior or public APIs; end-user functionality is unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->