### PR TITLE
Restrict `chardet` below v6 in `pylint` env

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -323,6 +323,9 @@ repos:
     - PyYAML  # needed by credentials.injectors, inventory.plugins
     - Sphinx  # needed by the Sphinx extension stub
     - tox  # needed by `toxfile.py`
+    # FIXME: drop the chardet constraint hack once `requests > 2.32.5` is out
+    - >-  # Ref: https://github.com/psf/requests/issues/7219
+      chardet < 6
 
 - repo: https://github.com/rhysd/actionlint.git
   rev: v1.7.10


### PR DESCRIPTION
This constraint hack can be reverted once `requests > 2.32.5` is out.

Ref: https://github.com/psf/requests/issues/7219.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit configuration to enforce stricter dependency version constraints for improved build stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->