### PR TITLE
🩹🧪 Pretend Coveralls isn't failing in CI

### DIFF
--- a/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-job/action.yml
+++ b/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-job/action.yml
@@ -32,6 +32,9 @@ runs:
     shell: bash
   - name: Send coverage data to Coveralls
     if: fromJSON(inputs.calling-job-context).toxenv == 'pre-commit'
+    # NOTE: Revert once https://github.com/ansible/awx-plugins/issues/164
+    # NOTE: is solved.
+    continue-on-error: true
     uses: coverallsapp/github-action@v2
     with:
       debug: ${{ runner.debug == 1 && true || false }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,6 +188,9 @@ linkcheck_ignore = [
     r'https://github\.com(/[^/]+){2}/actions',  # 404 if no auth
     r'^https://chat\.ansible\.im/#',  # these render fully on front-end
     r'^https://matrix\.to/#',  # these render fully on front-end from anchors
+    # NOTE: Revert once https://github.com/ansible/awx-plugins/issues/164 is
+    # NOTE: solved.
+    r'https://codecov\.io/',
 ]
 linkcheck_anchors_ignore_for_url = (
     r'^https://ansible\.r(eadthedocs|tfd)\.io'  # noqa: ISC004  # intentional


### PR DESCRIPTION
This patch suppresses coveralls outage-related problems in testing and linting.

It is to be reverted in full, once the outage is over.

Refs:
* https://github.com/ansible/awx-plugins/issues/164
* https://status.coveralls.io/incidents/pdbt7vdzlvpj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow resilience by allowing coverage upload steps to continue despite potential failures.
  * Updated documentation build configuration to suppress temporary link validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->