### PR TITLE
Revert "🩹🧪 Pretend Coveralls isn't failing in CI"

### DIFF
--- a/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-job/action.yml
+++ b/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-job/action.yml
@@ -32,9 +32,6 @@ runs:
     shell: bash
   - name: Send coverage data to Coveralls
     if: fromJSON(inputs.calling-job-context).toxenv == 'pre-commit'
-    # NOTE: Revert once https://github.com/ansible/awx-plugins/issues/164
-    # NOTE: is solved.
-    continue-on-error: true
     uses: coverallsapp/github-action@v2
     with:
       debug: ${{ runner.debug == 1 && true || false }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,9 +188,6 @@ linkcheck_ignore = [
     r'https://github\.com(/[^/]+){2}/actions',  # 404 if no auth
     r'^https://chat\.ansible\.im/#',  # these render fully on front-end
     r'^https://matrix\.to/#',  # these render fully on front-end from anchors
-    # NOTE: Revert once https://github.com/ansible/awx-plugins/issues/164 is
-    # NOTE: solved.
-    r'https://codecov\.io/',
 ]
 linkcheck_anchors_ignore_for_url = (
     r'^https://ansible\.r(eadthedocs|tfd)\.io'  # noqa: ISC004  # intentional


### PR DESCRIPTION
This reverts commit 02cb588ac25c39f193d4e7c3222a1bb741df763d.

Resolves #164.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling in the coverage reporting workflow to properly propagate failures instead of suppressing them.
  * Updated documentation link validation to include Codecov URLs in the validation process, ensuring all external references are verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->