### PR TITLE
Fix missing metadata fields on OIDC Credentials

### DIFF
--- a/src/awx_plugins/credentials/hashivault.py
+++ b/src/awx_plugins/credentials/hashivault.py
@@ -163,6 +163,16 @@ jwt_auth_path_field: _types.FieldDict = {
     ),
 }
 
+jwt_auth_path_metadata: _types.MetadataDict = {
+    'id': 'default_auth_path',
+    'label': _('Path to Auth'),
+    'type': 'string',
+    'multiline': False,
+    'help_text': _(
+        'The path where the JWT authentication method is mounted e.g, jwt',
+    ),
+}
+
 jwt_role_field: _types.FieldDict = {
     'id': 'jwt_role',
     'label': _('JWT Role'),
@@ -343,6 +353,7 @@ hashi_kv_oidc_inputs: _types.PluginInputs = {
     'metadata': [
         secret_backend_metadata,
         secret_path_metadata,
+        jwt_auth_path_metadata,
         secret_key_metadata,
         secret_version_metadata,
     ],
@@ -401,6 +412,7 @@ hashi_ssh_oidc_inputs: _types.PluginInputs = {
     'metadata': [
         public_key_metadata,
         secret_path_metadata,
+        jwt_auth_path_metadata,
         role_metadata,
         valid_principals_metadata,
     ],

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -295,6 +295,7 @@ def test_hashivault_handle_auth_not_enough_args() -> None:
             [
                 'secret_backend',
                 'secret_path',
+                'default_auth_path',
                 'secret_key',
                 'secret_version',
             ],
@@ -320,6 +321,7 @@ def test_hashivault_handle_auth_not_enough_args() -> None:
             [
                 'public_key',
                 'secret_path',
+                'default_auth_path',
                 'role',
                 'valid_principals',
             ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the HashiCorp Vault plugin metadata to expose an authentication path field across KV and SSH integrations, improving configuration visibility.
* **Tests**
  * Adjusted unit tests to align with the updated metadata surface so test expectations reflect the new configuration exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->