### PR TITLE
Let Sphinx's `linkcheck` linter skip GH blob URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,7 @@ linkcheck_ignore = [
     # Ref: https://github.com/ansible/awx-plugins/pull/172#issuecomment-4038249530
     # GitHub rate-limits unauthenticated HTTP requests aggressively, causing
     # linkcheck timeouts on blob URLs.
-    r'https://github\.com/(/[^/]+){2}/blob',
+    r'https://github\.com(/[^/]+){2}/blob',
 ]
 linkcheck_anchors_ignore_for_url = (
     r'^https://ansible\.r(eadthedocs|tfd)\.io'  # noqa: ISC004  # intentional

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,6 +188,10 @@ linkcheck_ignore = [
     r'https://github\.com(/[^/]+){2}/actions',  # 404 if no auth
     r'^https://chat\.ansible\.im/#',  # these render fully on front-end
     r'^https://matrix\.to/#',  # these render fully on front-end from anchors
+    # Ref: https://github.com/ansible/awx-plugins/pull/172#issuecomment-4038249530
+    # GitHub rate-limits unauthenticated HTTP requests aggressively, causing
+    # linkcheck timeouts on blob URLs.
+    r'https://github\.com/[^/]+/[^/]+/blob/devel/.*',
 ]
 linkcheck_anchors_ignore_for_url = (
     r'^https://ansible\.r(eadthedocs|tfd)\.io'  # noqa: ISC004  # intentional

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,7 @@ linkcheck_ignore = [
     # Ref: https://github.com/ansible/awx-plugins/pull/172#issuecomment-4038249530
     # GitHub rate-limits unauthenticated HTTP requests aggressively, causing
     # linkcheck timeouts on blob URLs.
-    r'https://github\.com/[^/]+/[^/]+/blob/devel/.*',
+    r'https://github\.com/(/[^/]+){2}/blob',
 ]
 linkcheck_anchors_ignore_for_url = (
     r'^https://ansible\.r(eadthedocs|tfd)\.io'  # noqa: ISC004  # intentional


### PR DESCRIPTION
Assisted-by: Claude

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation link checking now ignores specific GitHub blob URLs used in development paths, preventing timeouts from unauthenticated requests.
  * Result: more reliable docs builds, faster link-checking during validation, and fewer documentation build failures when publishing updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->