### PR TITLE
Fix #21: Prevent pytest from re-running full suite on coverage failure

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -540,6 +540,7 @@ jobs:
         --no-cov
         -vvvvv
         --lf
+        --last-failed-no-failures none
       tox-tool-deps: tox
       xfail: >-
         ${{


### PR DESCRIPTION
Fixes #21

### Summary
When `pytest-cov` triggers a failure due to the coverage threshold not being met, the `pytest --lf` command in the `tox-rerun-posargs` list evaluates an empty failure cache. By default, `pytest` responds to an empty `--lf` cache by re-running the entire test suite, which leads to inefficient use of CI resources.

This PR adds the `--last-failed-no-failures none` flag to the `ci-cd.yml` workflow. This overrides the default behavior, instructing `pytest` to fail fast and skip test execution if there are no actual functional test failures in the cache.

### Local Verification
Reproduced the issue locally by temporarily raising the `fail_under` threshold in `.coveragerc` to force a coverage failure, then executing the rerun logic.

**Before (Simulating coverage drop):**
```bash
.tox/py/bin/python -m pytest --no-cov --lf
```

**After (With flag applied):**
```bash
.tox/py/bin/python -m pytest --no-cov --lf --last-failed-no-failures none
```

**Result:** 
Pytest correctly identified no test failures and deselected the suite.
```
run-last-failure: no previously failed tests, deselecting all items.
========================= 132 deselected in 0.91s ==========================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to improve test rerun behavior so retrying tests won’t error when there are no prior failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->