### PR TITLE
Fix `flake8-logging-format` env compat under Python 3.11.15 @ GHA

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -185,7 +185,11 @@ repos:
     # NOTE: `flake8-logging-format`. `setuptools` stopped being bundled
     # NOTE: in CPython starting Python 3.12. The latest version of
     # NOTE: `setuptools` that's a part of Python 3.11.14 is v79.0.1.
-    - setuptools < 81; python_version >= "3.12" and python_version < "3.14"
+    # NOTE: This may also happen under Python 3.11.15 security release
+    # NOTE: as the underlying `virtualenv` invocation seems to be coming
+    # NOTE: pre-installing the newest available version of `setuptools`
+    # NOTE: from PyPI via its seeding mechanism.
+    - setuptools < 81; python_version < "3.14"
     - wemake-python-styleguide ~= 1.5.0
     language_version: python3
 


### PR DESCRIPTION
Previously [[1]], incompatibilities between `flake8-logging-format` and Python 3.14 had been discovered and a workaround applied in a form of only using it under older Python versions. As a part of the workaround, `setuptools` would be force-downgraded to something under v81. But the downgrade was only applied to Python 3.12 and 3.13. Now, we've seen evidence of the problem happening under Python 3.14.15. The underlying reason is muddy but it doesn't seem to be coming from the upstream release's `ensurepip`, nor GitHub's own Python build.

The working theory is that it's `virtualenv`'s seeding mechanism that upgrades or pre-installs `setuptools` from PyPI in that runtime now. `virtualenv` is used by the `pre-commit` framework to provision environments for individual linter invocations, which is where the incompatible version of `setuptools` seems to end up.

Now, this patch is makes sure to also downgrade `setuptools` under Python 3.11 too.

[1]: https://github.com/ansible/awx-plugins/pull/154

Here's a CI failure example being fixed:

```python-traceback
flake8........................................................................Failed
- hook id: flake8
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/plugins/finder.py", line 291, in _load_plugin
    obj = plugin.entry_point.load()
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/importlib/metadata/__init__.py", line 202, in load
    module = import_module(match.group('module'))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/logging_format/api.py", line 6, in <module>
    from logging_format.whitelist import Whitelist
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/logging_format/whitelist.py", line 5, in <module>
    from pkg_resources import iter_entry_points
ModuleNotFoundError: No module named 'pkg_resources'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/bin/flake8", line 6, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/main/cli.py", line 23, in main
    app.run(argv)
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/main/application.py", line 198, in run
    self._run(argv)
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/main/application.py", line 186, in _run
    self.initialize(argv)
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/main/application.py", line 165, in initialize
    self.plugins, self.options = parse_args(argv)
                                 ^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/options/parse_args.py", line 42, in parse_args
    plugins = finder.load_plugins(raw_plugins, plugin_opts)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/plugins/finder.py", line 365, in load_plugins
    return _classify_plugins(_import_plugins(plugins, opts), opts)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/plugins/finder.py", line 307, in _import_plugins
    return [_load_plugin(p) for p in plugins]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/plugins/finder.py", line 307, in <listcomp>
    return [_load_plugin(p) for p in plugins]
            ^^^^^^^^^^^^^^^
  File "/home/runner/.cache/pre-commit/repo2e5fmg5k/py_env-python3/lib/python3.11/site-packages/flake8/plugins/finder.py", line 293, in _load_plugin
    raise FailedToLoadPlugin(plugin.package, e)
flake8.exceptions.FailedToLoadPlugin: Flake8 failed to load plugin "flake8-logging-format" due to No module named 'pkg_resources'.
```

*(https://github.com/ansible/awx-plugins/actions/runs/23230770796/job/67523699956#step:16:115)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit configuration to broaden Python version compatibility constraints for development tools, expanding applicability across a wider range of supported Python versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->