### PR TITLE
AAP-67740 Add plugin_description support to CredentialPlugin

### DIFF
--- a/src/awx_plugins/credentials/hashivault.py
+++ b/src/awx_plugins/credentials/hashivault.py
@@ -649,10 +649,12 @@ hashivault_kv_oidc_plugin = CredentialPlugin(
     'HashiCorp Vault Secret Lookup (OIDC)',
     inputs=hashi_kv_oidc_inputs,
     backend=kv_backend,
+    plugin_description='Uses OIDC/JWT authentication for enhanced security with short-lived tokens',
 )
 
 hashivault_ssh_oidc_plugin = CredentialPlugin(
     'HashiCorp Vault Signed SSH (OIDC)',
     inputs=hashi_ssh_oidc_inputs,
     backend=ssh_backend,
+    plugin_description='Uses OIDC/JWT authentication for enhanced security with short-lived tokens',
 )

--- a/src/awx_plugins/credentials/plugin.py
+++ b/src/awx_plugins/credentials/plugin.py
@@ -16,6 +16,7 @@ class CredentialPlugin(typing.NamedTuple):
     name: str
     inputs: _types.PluginInputs
     backend: object
+    plugin_description: str = ''
 
 
 def raise_for_status(resp):

--- a/tests/unit/credentials/hashivault_test.py
+++ b/tests/unit/credentials/hashivault_test.py
@@ -391,3 +391,39 @@ def test_non_oidc_plugins_have_no_internal_fields(
         field for field in plugin.inputs['fields'] if field.get('internal')
     ]
     assert internal_fields == []
+
+
+@pytest.mark.parametrize(
+    'plugin',
+    (
+        pytest.param(hashivault.hashivault_kv_oidc_plugin, id='kv-oidc'),
+        pytest.param(hashivault.hashivault_ssh_oidc_plugin, id='ssh-oidc'),
+    ),
+)
+def test_oidc_plugin_has_description(plugin: CredentialPlugin) -> None:
+    """Verify OIDC plugins have a non-empty plugin_description."""
+    assert plugin.plugin_description != ''
+
+
+@pytest.mark.parametrize(
+    'plugin',
+    (
+        pytest.param(hashivault.hashivault_kv_plugin, id='kv'),
+        pytest.param(hashivault.hashivault_ssh_plugin, id='ssh'),
+    ),
+)
+def test_non_oidc_plugin_has_empty_description(
+    plugin: CredentialPlugin,
+) -> None:
+    """Verify non-OIDC plugins default to an empty plugin_description."""
+    assert plugin.plugin_description == ''
+
+
+def test_credential_plugin_description_default() -> None:
+    """Verify CredentialPlugin defaults plugin_description to empty string."""
+    plugin = CredentialPlugin(
+        name='test',
+        inputs={'fields': [], 'metadata': [], 'required': []},
+        backend=None,
+    )
+    assert plugin.plugin_description == ''


### PR DESCRIPTION
## Summary
- Add optional `plugin_description` field to `CredentialPlugin` NamedTuple (defaults to `''`)
- Set descriptions on the two OIDC HashiVault plugins (`hashivault_kv_oidc_plugin`, `hashivault_ssh_oidc_plugin`)
- Add unit tests for the new field

This enables AWX to pass credential plugin descriptions through to the UI. The companion AWX PR handles reading `plugin_description` and persisting it to `CredentialType.description`.

## Test plan
- [x] OIDC plugins have non-empty `plugin_description`
- [x] Non-OIDC plugins default to empty string
- [x] `CredentialPlugin` NamedTuple defaults `plugin_description` to `''`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credential plugins now include user-facing descriptions explaining authentication methods; HashiVault OIDC plugins indicate OIDC/JWT authentication with short-lived tokens.

* **Tests**
  * Added unit tests to ensure OIDC plugins provide non-empty descriptions and non-OIDC plugins retain empty descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->