### PR TITLE
feat: support default credential chain for AWS Secrets Manager

### DIFF
--- a/src/awx_plugins/credentials/aws_secretsmanager.py
+++ b/src/awx_plugins/credentials/aws_secretsmanager.py
@@ -40,8 +40,6 @@ secrets_manager_inputs: _types.PluginInputs = {
         },
     ],
     'required': [
-        'aws_access_key',
-        'aws_secret_key',
         'region_name',
         'secret_name',
     ],
@@ -51,8 +49,8 @@ secrets_manager_inputs: _types.PluginInputs = {
 def aws_secretsmanager_backend(**kwargs):
     secret_name = kwargs['secret_name']
     region_name = kwargs['region_name']
-    aws_secret_access_key = kwargs['aws_secret_key']
-    aws_access_key_id = kwargs['aws_access_key']
+    aws_secret_access_key = kwargs.get('aws_secret_key') or None
+    aws_access_key_id = kwargs.get('aws_access_key') or None
 
     session = boto3.session.Session()
     client = session.client(


### PR DESCRIPTION
Make the access key and secret key optional to support default credentials (e.g., pod identity)
are used without exposing keys.

Also, ensure that if only one of the two is provided,
the operation fails naturally. Fallbacks to default behavior may confuse users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS Secrets Manager credential plugin now treats access key and secret key as optional, allowing authentication via alternative mechanisms (e.g., IAM roles) when credentials are not provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->