### PR TITLE
test(credentials): align Azure Key Vault fake client signature

### DIFF
--- a/tests/azure_kv_test.py
+++ b/tests/azure_kv_test.py
@@ -19,7 +19,9 @@ class _FakeSecretClient(SecretClient):
         self: '_FakeSecretClient',
         name: str,
         version: str | None = None,
-        **kwargs: str,
+        *,
+        out_content_type: object | None = None,
+        **kwargs: object,
     ) -> KeyVaultSecret:
         props = SecretProperties()
         return KeyVaultSecret(properties=props, value='test-secret')


### PR DESCRIPTION
aligns the Azure Key Vault test fake with the current 
`SecretClient.get_secret` signature so pre-commit MyPy passes

This change was introduced in:
- https://github.com/Azure/azure-sdk-for-python/pull/45913