### PR TITLE
[AAPRFE-955] feat(credentials): add OAuth2 client_credentials token plugin

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -240,6 +240,7 @@ nitpick_ignore = [
     ('py:class', '_PT'),  # generic ParamSpec type variable
     ('py:class', '_contextvars.ContextVar'),  # unresolved context var type
     ('py:class', 'EnvVarsType'),
+    ('py:class', 'requests.models.Response'),
 ]
 
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -25,6 +25,7 @@ lookups
 namespace
 natively
 OAuth
+Okta
 OpenShift
 Ovirt
 ovirt
@@ -36,6 +37,7 @@ selinux
 Submodules
 Subpackages
 sudo
+synchronisation
 systemd
 templating
 Thycotic

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -11,11 +11,13 @@ doas
 ec
 ec2
 edu
+Entra
 Hashi
 hasn
 hostvars
 https
 ini
+Keycloak
 Kerberos
 keylogging
 Kubernetes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ thycotic_dsv = "awx_plugins.credentials.dsv:dsv_plugin"
 thycotic_tss = "awx_plugins.credentials.tss:tss_plugin"
 aws_secretsmanager_credential = "awx_plugins.credentials.aws_secretsmanager:aws_secretmanager_plugin"
 github_app_lookup = "awx_plugins.credentials.github_app:github_app_lookup"
+oauth2_client_credentials = "awx_plugins.credentials.oauth2_client_credentials:oauth2_client_credentials_plugin"
 
 [project.entry-points."awx_plugins.managed_credentials"] # new entry points group name
 ssh = "awx_plugins.credentials.plugins:ssh"
@@ -168,6 +169,10 @@ credentials-azure-kv = [
 credentials-github-app = [
   "awx_plugins.interfaces",
   "PyGithub",
+]
+credentials-oauth2-client-credentials = [
+  "awx_plugins.interfaces",
+  "requests",
 ]
 credentials-aim = [
   "awx_plugins.interfaces",

--- a/src/awx_plugins/credentials/oauth2_client_credentials.py
+++ b/src/awx_plugins/credentials/oauth2_client_credentials.py
@@ -17,17 +17,20 @@ Functions:
 
 from typing import TypedDict, Unpack
 
+import requests
+
 from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
     gettext_noop as _,
 )
-
-import requests
 
 from . import _types
 from .plugin import CredentialPlugin
 
 
 __all__ = ('oauth2_client_credentials_plugin',)  # noqa: WPS410
+
+_REQUEST_TIMEOUT_SECONDS = 30
+
 
 oauth2_client_credentials_inputs: _types.PluginInputs = {
     'fields': [
@@ -79,6 +82,73 @@ class EmptyKwargs(TypedDict):
     """Schema for zero keyword arguments."""
 
 
+def _extract_error_detail(resp: requests.Response) -> str:
+    """Pull a human-readable error from a non-200 response.
+
+    :param resp: The failed HTTP response.
+    :returns: An error description string.
+    """
+    try:
+        body = resp.json()
+    except ValueError:
+        return resp.text
+
+    if not isinstance(body, dict):
+        return resp.text
+    return str(body.get('error_description', resp.text))
+
+
+def _post_token_request(
+    token_url: str,
+    post_data: dict[str, str],
+) -> requests.Response:
+    """POST to the token endpoint, converting transport errors.
+
+    :param token_url: The full OAuth2 token endpoint URL.
+    :param post_data: The form data to send.
+    :returns: The HTTP response.
+    :raises ValueError: On timeout or connection failure.
+    """
+    try:
+        return requests.post(
+            token_url,
+            data=post_data,
+            timeout=_REQUEST_TIMEOUT_SECONDS,
+        )
+    except requests.exceptions.Timeout as timeout_exc:
+        raise ValueError(
+            f'Timed out requesting token from {token_url!s}',
+        ) from timeout_exc
+    except requests.exceptions.ConnectionError as conn_exc:
+        raise ValueError(
+            f'Could not connect to token endpoint: {token_url!s}',
+        ) from conn_exc
+
+
+def _extract_access_token(resp: requests.Response) -> str:
+    """Parse the access_token from a successful token response.
+
+    :param resp: A 200 HTTP response from the token endpoint.
+    :returns: The bearer access token string.
+    :raises ValueError: If the response body is not valid JSON,
+        is not a JSON object, or lacks ``access_token``.
+    """
+    try:
+        body = resp.json()
+    except ValueError as parse_exc:
+        raise ValueError(
+            'Token endpoint response did not contain '
+            'an access_token field',
+        ) from parse_exc
+
+    if not isinstance(body, dict) or 'access_token' not in body:
+        raise ValueError(
+            'Token endpoint response did not contain '
+            'an access_token field',
+        )
+    return str(body['access_token'])
+
+
 def oauth2_client_credentials_backend(
     *,
     token_url: str,
@@ -102,7 +172,7 @@ def oauth2_client_credentials_backend(
     :raises ValueError: If the token request fails or the response
         is missing the ``access_token`` field.
     """
-    post_data = {
+    post_data: dict[str, str] = {
         'grant_type': 'client_credentials',
         'client_id': client_id,
         'client_secret': client_secret,
@@ -110,46 +180,16 @@ def oauth2_client_credentials_backend(
     if scope:
         post_data['scope'] = scope
 
-    try:
-        resp = requests.post(token_url, data=post_data, timeout=30)
-    except requests.exceptions.Timeout as timeout_exc:
-        raise ValueError(
-            f'Timed out requesting token from {token_url!s}',
-        ) from timeout_exc
-    except requests.exceptions.ConnectionError as conn_exc:
-        raise ValueError(
-            f'Could not connect to token endpoint: {token_url!s}',
-        ) from conn_exc
+    resp = _post_token_request(token_url, post_data)
 
     if resp.status_code != 200:  # noqa: WPS432
-        error_detail = ''
-        try:
-            body = resp.json()
-            if isinstance(body, dict):
-                error_detail = body.get('error_description', resp.text)
-            else:
-                error_detail = resp.text
-        except ValueError:
-            error_detail = resp.text
-
         raise ValueError(
             'Token request failed '
-            f'(HTTP {resp.status_code}): {error_detail!s}',
+            f'(HTTP {resp.status_code}): '
+            f'{_extract_error_detail(resp)!s}',
         )
 
-    try:
-        body = resp.json()
-    except ValueError as parse_exc:
-        raise ValueError(
-            'Token endpoint response did not contain an access_token field',
-        ) from parse_exc
-
-    if not isinstance(body, dict) or 'access_token' not in body:
-        raise ValueError(
-            'Token endpoint response did not contain '
-            'an access_token field',
-        )
-    return body['access_token']
+    return _extract_access_token(resp)
 
 
 oauth2_client_credentials_plugin = CredentialPlugin(

--- a/src/awx_plugins/credentials/oauth2_client_credentials.py
+++ b/src/awx_plugins/credentials/oauth2_client_credentials.py
@@ -98,6 +98,19 @@ def _extract_error_detail(resp: requests.Response) -> str:
     return str(body.get('error_description', resp.text))
 
 
+def _require_https(token_url: str) -> None:
+    """Ensure the token endpoint uses ``https`` before sending secrets.
+
+    :param token_url: The full OAuth2 token endpoint URL.
+    :raises ValueError: If ``token_url`` does not use the ``https``
+        scheme.
+    """
+    if not token_url.lower().startswith('https://'):
+        raise ValueError(
+            f'Token endpoint must use https: {token_url!s}',
+        )
+
+
 def _post_token_request(
     token_url: str,
     post_data: dict[str, str],
@@ -109,6 +122,8 @@ def _post_token_request(
     :returns: The HTTP response.
     :raises ValueError: On any transport-level failure.
     """
+    _require_https(token_url)
+
     try:
         return requests.post(
             token_url,
@@ -144,11 +159,12 @@ def _extract_access_token(resp: requests.Response) -> str:
             'Token endpoint response did not contain an access_token field',
         ) from parse_exc
 
-    if not isinstance(body, dict) or 'access_token' not in body:
+    token = body.get('access_token') if isinstance(body, dict) else None
+    if not token:
         raise ValueError(
             'Token endpoint response did not contain an access_token field',
         )
-    return str(body['access_token'])
+    return str(token)
 
 
 def oauth2_client_credentials_backend(

--- a/src/awx_plugins/credentials/oauth2_client_credentials.py
+++ b/src/awx_plugins/credentials/oauth2_client_credentials.py
@@ -1,0 +1,159 @@
+"""OAuth2 Client Credentials Token Credential Plugin.
+
+This module defines a credential plugin that fetches a short-lived
+bearer token using the OAuth 2.0 ``client_credentials`` grant.
+Works with any compliant token endpoint including Microsoft Entra ID
+(Azure AD), Keycloak, Okta, and others.
+
+Primary use case: Azure DevOps project synchronisation after PAT/SSH
+deprecation, using a Microsoft Entra Service Principal.
+
+Functions:
+
+- :func:`oauth2_client_credentials_backend`: Fetches an OAuth2 token.
+- ``oauth2_client_credentials_plugin``: Defines the credential plugin
+  interface.
+"""
+
+from typing import TypedDict, Unpack
+
+import requests
+
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
+from . import _types
+from .plugin import CredentialPlugin
+
+__all__ = ('oauth2_client_credentials_plugin',)  # noqa: WPS410
+
+oauth2_client_credentials_inputs: _types.PluginInputs = {
+    'fields': [
+        {
+            'id': 'token_url',
+            'label': _('Token Endpoint URL'),
+            'type': 'string',
+            'help_text': _(
+                'The full OAuth2 token endpoint URL. '
+                'For Microsoft Entra ID: '
+                'https://login.microsoftonline.com/'
+                '<TENANT_ID>/oauth2/v2.0/token',
+            ),
+        },
+        {
+            'id': 'client_id',
+            'label': _('Client ID'),
+            'type': 'string',
+            'help_text': _(
+                'The OAuth2 client identifier '
+                '(Application ID for Microsoft Entra).',
+            ),
+        },
+        {
+            'id': 'client_secret',
+            'label': _('Client Secret'),
+            'type': 'string',
+            'secret': True,
+            'help_text': _('The OAuth2 client secret.'),
+        },
+    ],
+    'metadata': [
+        {
+            'id': 'scope',
+            'label': _('Scope (optional)'),
+            'type': 'string',
+            'help_text': _(
+                'The OAuth2 scope to request. '
+                'For Azure DevOps: '
+                '499b84ac-1321-427f-aa17-267ca6975798/.default',
+            ),
+        },
+    ],
+    'required': ['token_url', 'client_id', 'client_secret'],
+}
+
+
+class EmptyKwargs(TypedDict):
+    """Schema for zero keyword arguments."""
+
+
+def oauth2_client_credentials_backend(
+    *,
+    token_url: str,
+    client_id: str,
+    client_secret: str,
+    scope: str = '',
+    **_discarded_kwargs: Unpack[EmptyKwargs],
+) -> str:
+    """Fetch an OAuth 2.0 access token via the client_credentials grant.
+
+    Called each time a linked credential value needs to be resolved.
+    The token is never cached; a fresh one is requested on every
+    lookup.
+
+    :param token_url: The full OAuth2 token endpoint URL.
+    :param client_id: The OAuth2 client identifier.
+    :param client_secret: The OAuth2 client secret.
+    :param scope: Optional OAuth2 scope to request.
+    :param _discarded_kwargs: Aren't expected to be passed.
+    :returns: A bearer access token string.
+    :raises ValueError: If the token request fails or the response
+        is missing the ``access_token`` field.
+    """
+    post_data = {
+        'grant_type': 'client_credentials',
+        'client_id': client_id,
+        'client_secret': client_secret,
+    }
+    if scope:
+        post_data['scope'] = scope
+
+    try:
+        resp = requests.post(token_url, data=post_data, timeout=30)
+    except requests.exceptions.Timeout as timeout_exc:
+        raise ValueError(
+            'Timed out requesting token from '
+            f'{token_url!s}',
+        ) from timeout_exc
+    except requests.exceptions.ConnectionError as conn_exc:
+        raise ValueError(
+            'Could not connect to token endpoint: '
+            f'{token_url!s}',
+        ) from conn_exc
+
+    if resp.status_code != 200:  # noqa: WPS432
+        error_detail = ''
+        try:
+            body = resp.json()
+            error_detail = body.get(
+                'error_description',
+                resp.text,
+            )
+        except ValueError:
+            error_detail = resp.text
+
+        raise ValueError(
+            'Token request failed '
+            f'(HTTP {resp.status_code}): {error_detail!s}',
+        )
+
+    try:
+        return resp.json()['access_token']
+    except (KeyError, ValueError) as parse_exc:
+        raise ValueError(
+            'Token endpoint response did not contain '
+            'an access_token field',
+        ) from parse_exc
+
+
+oauth2_client_credentials_plugin = CredentialPlugin(
+    'OAuth2 Client Credentials Token Lookup',
+    inputs=oauth2_client_credentials_inputs,
+    backend=oauth2_client_credentials_backend,
+    plugin_description=(
+        'Fetch a short-lived OAuth2 bearer token using the '
+        'client_credentials grant. Works with Entra ID, '
+        'Keycloak, Okta, and any compliant provider.'
+    ),
+)

--- a/src/awx_plugins/credentials/oauth2_client_credentials.py
+++ b/src/awx_plugins/credentials/oauth2_client_credentials.py
@@ -17,11 +17,11 @@ Functions:
 
 from typing import TypedDict, Unpack
 
-import requests
-
 from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
     gettext_noop as _,
 )
+
+import requests
 
 from . import _types
 from .plugin import CredentialPlugin
@@ -137,14 +137,12 @@ def _extract_access_token(resp: requests.Response) -> str:
         body = resp.json()
     except ValueError as parse_exc:
         raise ValueError(
-            'Token endpoint response did not contain '
-            'an access_token field',
+            'Token endpoint response did not contain an access_token field',
         ) from parse_exc
 
     if not isinstance(body, dict) or 'access_token' not in body:
         raise ValueError(
-            'Token endpoint response did not contain '
-            'an access_token field',
+            'Token endpoint response did not contain an access_token field',
         )
     return str(body['access_token'])
 

--- a/src/awx_plugins/credentials/oauth2_client_credentials.py
+++ b/src/awx_plugins/credentials/oauth2_client_credentials.py
@@ -89,7 +89,7 @@ def _extract_error_detail(resp: requests.Response) -> str:
     :returns: An error description string.
     """
     try:
-        body = resp.json()
+        body: object = resp.json()
     except ValueError:
         return resp.text
 
@@ -134,7 +134,7 @@ def _extract_access_token(resp: requests.Response) -> str:
         is not a JSON object, or lacks ``access_token``.
     """
     try:
-        body = resp.json()
+        body: object = resp.json()
     except ValueError as parse_exc:
         raise ValueError(
             'Token endpoint response did not contain an access_token field',

--- a/src/awx_plugins/credentials/oauth2_client_credentials.py
+++ b/src/awx_plugins/credentials/oauth2_client_credentials.py
@@ -17,14 +17,15 @@ Functions:
 
 from typing import TypedDict, Unpack
 
-import requests
-
 from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
     gettext_noop as _,
 )
 
+import requests
+
 from . import _types
 from .plugin import CredentialPlugin
+
 
 __all__ = ('oauth2_client_credentials_plugin',)  # noqa: WPS410
 
@@ -113,13 +114,11 @@ def oauth2_client_credentials_backend(
         resp = requests.post(token_url, data=post_data, timeout=30)
     except requests.exceptions.Timeout as timeout_exc:
         raise ValueError(
-            'Timed out requesting token from '
-            f'{token_url!s}',
+            f'Timed out requesting token from {token_url!s}',
         ) from timeout_exc
     except requests.exceptions.ConnectionError as conn_exc:
         raise ValueError(
-            'Could not connect to token endpoint: '
-            f'{token_url!s}',
+            f'Could not connect to token endpoint: {token_url!s}',
         ) from conn_exc
 
     if resp.status_code != 200:  # noqa: WPS432
@@ -142,8 +141,7 @@ def oauth2_client_credentials_backend(
         return resp.json()['access_token']
     except (KeyError, ValueError) as parse_exc:
         raise ValueError(
-            'Token endpoint response did not contain '
-            'an access_token field',
+            'Token endpoint response did not contain an access_token field',
         ) from parse_exc
 
 

--- a/src/awx_plugins/credentials/oauth2_client_credentials.py
+++ b/src/awx_plugins/credentials/oauth2_client_credentials.py
@@ -125,10 +125,10 @@ def oauth2_client_credentials_backend(
         error_detail = ''
         try:
             body = resp.json()
-            error_detail = body.get(
-                'error_description',
-                resp.text,
-            )
+            if isinstance(body, dict):
+                error_detail = body.get('error_description', resp.text)
+            else:
+                error_detail = resp.text
         except ValueError:
             error_detail = resp.text
 
@@ -138,11 +138,18 @@ def oauth2_client_credentials_backend(
         )
 
     try:
-        return resp.json()['access_token']
-    except (KeyError, ValueError) as parse_exc:
+        body = resp.json()
+    except ValueError as parse_exc:
         raise ValueError(
             'Token endpoint response did not contain an access_token field',
         ) from parse_exc
+
+    if not isinstance(body, dict) or 'access_token' not in body:
+        raise ValueError(
+            'Token endpoint response did not contain '
+            'an access_token field',
+        )
+    return body['access_token']
 
 
 oauth2_client_credentials_plugin = CredentialPlugin(

--- a/src/awx_plugins/credentials/oauth2_client_credentials.py
+++ b/src/awx_plugins/credentials/oauth2_client_credentials.py
@@ -107,7 +107,7 @@ def _post_token_request(
     :param token_url: The full OAuth2 token endpoint URL.
     :param post_data: The form data to send.
     :returns: The HTTP response.
-    :raises ValueError: On timeout or connection failure.
+    :raises ValueError: On any transport-level failure.
     """
     try:
         return requests.post(
@@ -123,6 +123,10 @@ def _post_token_request(
         raise ValueError(
             f'Could not connect to token endpoint: {token_url!s}',
         ) from conn_exc
+    except requests.exceptions.RequestException as req_exc:
+        raise ValueError(
+            f'Failed requesting token from endpoint: {token_url!s}',
+        ) from req_exc
 
 
 def _extract_access_token(resp: requests.Response) -> str:

--- a/tests/importable_test.py
+++ b/tests/importable_test.py
@@ -80,6 +80,11 @@ credential_plugins = (
         'aws_secretsmanager_credential',
         'awx_plugins.credentials.aws_secretsmanager:aws_secretmanager_plugin',
     ),
+    EntryPointParam(
+        'awx_plugins.credentials',
+        'oauth2_client_credentials',
+        'awx_plugins.credentials.oauth2_client_credentials:oauth2_client_credentials_plugin',
+    ),
 )
 
 

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -23,8 +23,8 @@ FAKE_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.fake.token'  # noqa: S105
 class _FakeResponse:
     """Minimal stand-in for ``requests.Response``."""
 
-    def __init__(  # noqa: ANN101
-        self,
+    def __init__(
+        self,  # noqa: ANN101
         status_code: int,
         json_data: object = None,
         text: str = '',

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -220,7 +220,7 @@ def test_works_with_various_providers(
     token_url: str,
 ) -> None:
     """Verify the plugin works with different OAuth2 provider URLs."""
-    mocker.patch.object(
+    mock_post = mocker.patch.object(
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
@@ -230,6 +230,7 @@ def test_works_with_various_providers(
     )
 
     assert call_backend(token_url=token_url) == FAKE_TOKEN
+    assert mock_post.call_args[0][0] == token_url
 
 
 @pytest.mark.parametrize(

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -10,6 +10,7 @@ from awx_plugins.credentials import (
     oauth2_client_credentials as oauth2_mod,
 )
 
+
 TOKEN_URL = (
     'https://login.microsoftonline.com'
     '/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token'
@@ -43,6 +44,7 @@ class _FakeResponse:
 @pytest.fixture
 def call_backend() -> _BackendCaller:
     """Return a helper that calls the backend with default credentials."""
+
     def _invoke(**overrides: str) -> str:
         kwargs: dict[str, str] = {
             'token_url': TOKEN_URL,
@@ -51,6 +53,7 @@ def call_backend() -> _BackendCaller:
         }
         kwargs.update(overrides)
         return oauth2_mod.oauth2_client_credentials_backend(**kwargs)
+
     return _invoke
 
 

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -1,7 +1,7 @@
 """Tests for the OAuth2 Client Credentials Token credential plugin."""
 
 import http
-from collections.abc import Callable
+from typing import NamedTuple, Protocol
 
 import pytest
 from pytest_mock import MockerFixture
@@ -18,7 +18,24 @@ TOKEN_URL = (
 ADO_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default'
 FAKE_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.fake.token'  # noqa: S105
 
-_BackendCaller = Callable[..., str]
+
+class _BackendCaller(Protocol):
+    """Typing protocol for the ``call_backend`` fixture."""
+
+    def __call__(
+        self,  # noqa: ANN101
+        **overrides: str,
+    ) -> str:
+        """Call the backend with optional credential overrides."""
+
+
+class _ErrorCase(NamedTuple):
+    """Parameters for an HTTP error test case."""
+
+    status_code: int
+    json_data: object
+    text: str
+    error_pattern: str
 
 
 class _FakeResponse:
@@ -169,10 +186,10 @@ def test_no_scope_omits_scope_from_request(
         ),
     )
 
-    if scope_value is not None:
-        call_backend(scope=scope_value)
-    else:
+    if scope_value is None:
         call_backend()
+    else:
+        call_backend(scope=scope_value)
 
     post_data = mock_post.call_args[1]['data']
     assert 'scope' not in post_data
@@ -216,45 +233,50 @@ def test_works_with_various_providers(
 
 
 @pytest.mark.parametrize(
-    (
-        'status_code',
-        'json_data',
-        'text',
-        'error_pattern',
-    ),
+    'error_case',
     (
         pytest.param(
-            http.HTTPStatus.UNAUTHORIZED,
-            {
-                'error': 'invalid_client',
-                'error_description': 'Invalid client secret provided.',
-            },
-            '',
-            r'Token request failed.*HTTP 401.*Invalid client secret',
+            _ErrorCase(
+                status_code=http.HTTPStatus.UNAUTHORIZED,
+                json_data={
+                    'error': 'invalid_client',
+                    'error_description': 'Invalid client secret provided.',
+                },
+                text='',
+                error_pattern=(
+                    r'Token request failed.*HTTP 401.*Invalid client secret'
+                ),
+            ),
             id='invalid-credentials',
         ),
         pytest.param(
-            http.HTTPStatus.BAD_REQUEST,
-            {
-                'error': 'invalid_request',
-                'error_description': 'Tenant not found.',
-            },
-            '',
-            r'Tenant not found',
+            _ErrorCase(
+                status_code=http.HTTPStatus.BAD_REQUEST,
+                json_data={
+                    'error': 'invalid_request',
+                    'error_description': 'Tenant not found.',
+                },
+                text='',
+                error_pattern=r'Tenant not found',
+            ),
             id='bad-request',
         ),
         pytest.param(
-            http.HTTPStatus.SERVICE_UNAVAILABLE,
-            None,
-            'Service Unavailable',
-            r'HTTP 503.*Service Unavailable',
+            _ErrorCase(
+                status_code=http.HTTPStatus.SERVICE_UNAVAILABLE,
+                json_data=None,
+                text='Service Unavailable',
+                error_pattern=r'HTTP 503.*Service Unavailable',
+            ),
             id='non-json-error',
         ),
         pytest.param(
-            http.HTTPStatus.BAD_REQUEST,
-            ['not', 'a', 'dict'],
-            'Bad Request',
-            r'HTTP 400.*Bad Request',
+            _ErrorCase(
+                status_code=http.HTTPStatus.BAD_REQUEST,
+                json_data=['not', 'a', 'dict'],
+                text='Bad Request',
+                error_pattern=r'HTTP 400.*Bad Request',
+            ),
             id='non-dict-json-error',
         ),
     ),
@@ -262,23 +284,20 @@ def test_works_with_various_providers(
 def test_http_errors_raise_value_error(
     mocker: MockerFixture,
     call_backend: _BackendCaller,
-    status_code: int,
-    json_data: object,
-    text: str,
-    error_pattern: str,
+    error_case: _ErrorCase,
 ) -> None:
     """Test that HTTP errors are converted to ValueError."""
     mocker.patch.object(
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=status_code,
-            json_data=json_data,
-            text=text,
+            status_code=error_case.status_code,
+            json_data=error_case.json_data,
+            text=error_case.text,
         ),
     )
 
-    with pytest.raises(ValueError, match=error_pattern):
+    with pytest.raises(ValueError, match=error_case.error_pattern):
         call_backend()
 
 

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -1,6 +1,7 @@
 """Tests for the OAuth2 Client Credentials Token credential plugin."""
 
 import http
+from collections.abc import Callable
 
 import pytest
 from pytest_mock import MockerFixture
@@ -9,18 +10,14 @@ from awx_plugins.credentials import (
     oauth2_client_credentials as oauth2_mod,
 )
 
-
 TOKEN_URL = (
     'https://login.microsoftonline.com'
     '/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token'
 )
-_COMMON_BACKEND_KWARGS: dict[str, str] = {
-    'token_url': TOKEN_URL,
-    'client_id': '11111111-1111-1111-1111-111111111111',
-    'client_secret': 'test-secret-value',  # noqa: S105
-}
 ADO_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default'
 FAKE_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.fake.token'  # noqa: S105
+
+_BackendCaller = Callable[..., str]
 
 
 class _FakeResponse:
@@ -41,6 +38,20 @@ class _FakeResponse:
         if self._json_data is None:
             raise ValueError('No JSON')
         return self._json_data
+
+
+@pytest.fixture
+def call_backend() -> _BackendCaller:
+    """Return a helper that calls the backend with default credentials."""
+    def _invoke(**overrides: str) -> str:
+        kwargs: dict[str, str] = {
+            'token_url': TOKEN_URL,
+            'client_id': '11111111-1111-1111-1111-111111111111',
+            'client_secret': 'test-secret-value',  # noqa: S105
+        }
+        kwargs.update(overrides)
+        return oauth2_mod.oauth2_client_credentials_backend(**kwargs)
+    return _invoke
 
 
 def test_plugin_name() -> None:
@@ -91,7 +102,10 @@ def test_plugin_has_description() -> None:
     assert 'OAuth2' in desc
 
 
-def test_successful_token_fetch(mocker: MockerFixture) -> None:
+def test_successful_token_fetch(
+    mocker: MockerFixture,
+    call_backend: _BackendCaller,
+) -> None:
     """Test a successful token retrieval."""
     mocker.patch.object(
         oauth2_mod.requests,
@@ -106,15 +120,13 @@ def test_successful_token_fetch(mocker: MockerFixture) -> None:
         ),
     )
 
-    token = oauth2_mod.oauth2_client_credentials_backend(
-        **_COMMON_BACKEND_KWARGS,
-        scope=ADO_SCOPE,
-    )
-
-    assert token == FAKE_TOKEN
+    assert call_backend(scope=ADO_SCOPE) == FAKE_TOKEN
 
 
-def test_request_includes_grant_type(mocker: MockerFixture) -> None:
+def test_request_includes_grant_type(
+    mocker: MockerFixture,
+    call_backend: _BackendCaller,
+) -> None:
     """Verify the POST body includes grant_type=client_credentials."""
     mock_post = mocker.patch.object(
         oauth2_mod.requests,
@@ -125,15 +137,10 @@ def test_request_includes_grant_type(mocker: MockerFixture) -> None:
         ),
     )
 
-    oauth2_mod.oauth2_client_credentials_backend(
-        **_COMMON_BACKEND_KWARGS,
-        scope=ADO_SCOPE,
-    )
+    call_backend(scope=ADO_SCOPE)
 
-    call_kwargs = mock_post.call_args
-    post_data = call_kwargs[1]['data']
+    post_data = mock_post.call_args[1]['data']
     assert post_data['grant_type'] == 'client_credentials'
-    assert post_data['client_id'] == _COMMON_BACKEND_KWARGS['client_id']
     assert post_data['scope'] == ADO_SCOPE
 
 
@@ -146,6 +153,7 @@ def test_request_includes_grant_type(mocker: MockerFixture) -> None:
 )
 def test_no_scope_omits_scope_from_request(
     mocker: MockerFixture,
+    call_backend: _BackendCaller,
     scope_value: str | None,
 ) -> None:
     """Verify that an empty or missing scope is not sent."""
@@ -158,11 +166,10 @@ def test_no_scope_omits_scope_from_request(
         ),
     )
 
-    kwargs = dict(_COMMON_BACKEND_KWARGS)
     if scope_value is not None:
-        kwargs['scope'] = scope_value
-
-    oauth2_mod.oauth2_client_credentials_backend(**kwargs)
+        call_backend(scope=scope_value)
+    else:
+        call_backend()
 
     post_data = mock_post.call_args[1]['data']
     assert 'scope' not in post_data
@@ -189,6 +196,7 @@ def test_no_scope_omits_scope_from_request(
 )
 def test_works_with_various_providers(
     mocker: MockerFixture,
+    call_backend: _BackendCaller,
     token_url: str,
 ) -> None:
     """Verify the plugin works with different OAuth2 provider URLs."""
@@ -201,17 +209,14 @@ def test_works_with_various_providers(
         ),
     )
 
-    token = oauth2_mod.oauth2_client_credentials_backend(
-        **{**_COMMON_BACKEND_KWARGS, 'token_url': token_url},
-    )
-
-    assert token == FAKE_TOKEN
+    assert call_backend(token_url=token_url) == FAKE_TOKEN
 
 
 @pytest.mark.parametrize(
     (
         'status_code',
-        'response_body',
+        'json_data',
+        'text',
         'error_pattern',
     ),
     (
@@ -221,6 +226,7 @@ def test_works_with_various_providers(
                 'error': 'invalid_client',
                 'error_description': 'Invalid client secret provided.',
             },
+            '',
             r'Token request failed.*HTTP 401.*Invalid client secret',
             id='invalid-credentials',
         ),
@@ -230,15 +236,32 @@ def test_works_with_various_providers(
                 'error': 'invalid_request',
                 'error_description': 'Tenant not found.',
             },
+            '',
             r'Tenant not found',
             id='bad-request',
+        ),
+        pytest.param(
+            http.HTTPStatus.SERVICE_UNAVAILABLE,
+            None,
+            'Service Unavailable',
+            r'HTTP 503.*Service Unavailable',
+            id='non-json-error',
+        ),
+        pytest.param(
+            http.HTTPStatus.BAD_REQUEST,
+            ['not', 'a', 'dict'],
+            'Bad Request',
+            r'HTTP 400.*Bad Request',
+            id='non-dict-json-error',
         ),
     ),
 )
 def test_http_errors_raise_value_error(
     mocker: MockerFixture,
+    call_backend: _BackendCaller,
     status_code: int,
-    response_body: dict[str, str],
+    json_data: object,
+    text: str,
     error_pattern: str,
 ) -> None:
     """Test that HTTP errors are converted to ValueError."""
@@ -247,49 +270,52 @@ def test_http_errors_raise_value_error(
         'post',
         return_value=_FakeResponse(
             status_code=status_code,
-            json_data=response_body,
+            json_data=json_data,
+            text=text,
         ),
     )
 
     with pytest.raises(ValueError, match=error_pattern):
-        oauth2_mod.oauth2_client_credentials_backend(
-            **_COMMON_BACKEND_KWARGS,
-        )
+        call_backend()
 
 
-def test_non_json_error_response(mocker: MockerFixture) -> None:
-    """Test handling of non-JSON error responses."""
-    mocker.patch.object(
-        oauth2_mod.requests,
-        'post',
-        return_value=_FakeResponse(
-            status_code=http.HTTPStatus.SERVICE_UNAVAILABLE,
-            text='Service Unavailable',
+@pytest.mark.parametrize(
+    (
+        'json_data',
+        'text',
+    ),
+    (
+        pytest.param(
+            {'token_type': 'Bearer', 'expires_in': 3600},
+            '',
+            id='missing-access-token-key',
         ),
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r'HTTP 503.*Service Unavailable',
-    ):
-        oauth2_mod.oauth2_client_credentials_backend(
-            **_COMMON_BACKEND_KWARGS,
-        )
-
-
-def test_missing_access_token_in_response(
+        pytest.param(
+            ['not', 'a', 'dict'],
+            '',
+            id='non-dict-json',
+        ),
+        pytest.param(
+            None,
+            'not json at all',
+            id='unparseable-json',
+        ),
+    ),
+)
+def test_malformed_success_response(
     mocker: MockerFixture,
+    call_backend: _BackendCaller,
+    json_data: object,
+    text: str,
 ) -> None:
-    """Test handling of responses without an access_token field."""
+    """Test handling of 200 responses without a usable access_token."""
     mocker.patch.object(
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
             status_code=http.HTTPStatus.OK,
-            json_data={
-                'token_type': 'Bearer',
-                'expires_in': 3600,
-            },
+            json_data=json_data,
+            text=text,
         ),
     )
 
@@ -297,79 +323,13 @@ def test_missing_access_token_in_response(
         ValueError,
         match=r'did not contain an access_token',
     ):
-        oauth2_mod.oauth2_client_credentials_backend(
-            **_COMMON_BACKEND_KWARGS,
-        )
+        call_backend()
 
 
-def test_non_dict_json_success_response(
+def test_connection_error(
     mocker: MockerFixture,
+    call_backend: _BackendCaller,
 ) -> None:
-    """Test handling of a 200 response whose JSON is not an object."""
-    mocker.patch.object(
-        oauth2_mod.requests,
-        'post',
-        return_value=_FakeResponse(
-            status_code=http.HTTPStatus.OK,
-            json_data=['not', 'a', 'dict'],
-        ),
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r'did not contain an access_token',
-    ):
-        oauth2_mod.oauth2_client_credentials_backend(
-            **_COMMON_BACKEND_KWARGS,
-        )
-
-
-def test_non_dict_json_error_response(
-    mocker: MockerFixture,
-) -> None:
-    """Test handling of an error response whose JSON is not an object."""
-    mocker.patch.object(
-        oauth2_mod.requests,
-        'post',
-        return_value=_FakeResponse(
-            status_code=http.HTTPStatus.BAD_REQUEST,
-            json_data=['not', 'a', 'dict'],
-            text='Bad Request',
-        ),
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r'HTTP 400.*Bad Request',
-    ):
-        oauth2_mod.oauth2_client_credentials_backend(
-            **_COMMON_BACKEND_KWARGS,
-        )
-
-
-def test_unparseable_json_success_response(
-    mocker: MockerFixture,
-) -> None:
-    """Test handling of a 200 response with non-JSON body."""
-    mocker.patch.object(
-        oauth2_mod.requests,
-        'post',
-        return_value=_FakeResponse(
-            status_code=http.HTTPStatus.OK,
-            text='not json at all',
-        ),
-    )
-
-    with pytest.raises(
-        ValueError,
-        match=r'did not contain an access_token',
-    ):
-        oauth2_mod.oauth2_client_credentials_backend(
-            **_COMMON_BACKEND_KWARGS,
-        )
-
-
-def test_connection_error(mocker: MockerFixture) -> None:
     """Test that connection errors are wrapped in ValueError."""
     mocker.patch.object(
         oauth2_mod.requests,
@@ -383,12 +343,13 @@ def test_connection_error(mocker: MockerFixture) -> None:
         ValueError,
         match=r'Could not connect to token endpoint',
     ):
-        oauth2_mod.oauth2_client_credentials_backend(
-            **_COMMON_BACKEND_KWARGS,
-        )
+        call_backend()
 
 
-def test_timeout_error(mocker: MockerFixture) -> None:
+def test_timeout_error(
+    mocker: MockerFixture,
+    call_backend: _BackendCaller,
+) -> None:
     """Test that timeout errors are wrapped in ValueError."""
     mocker.patch.object(
         oauth2_mod.requests,
@@ -402,12 +363,12 @@ def test_timeout_error(mocker: MockerFixture) -> None:
         ValueError,
         match=r'Timed out requesting token',
     ):
-        oauth2_mod.oauth2_client_credentials_backend(
-            **_COMMON_BACKEND_KWARGS,
-        )
+        call_backend()
 
 
-def test_discarded_kwargs_are_ignored(mocker: MockerFixture) -> None:
+def test_discarded_kwargs_are_ignored(
+    mocker: MockerFixture,
+) -> None:
     """Verify unexpected kwargs don't break the backend."""
     mocker.patch.object(
         oauth2_mod.requests,
@@ -419,7 +380,9 @@ def test_discarded_kwargs_are_ignored(mocker: MockerFixture) -> None:
     )
 
     token = oauth2_mod.oauth2_client_credentials_backend(
-        **_COMMON_BACKEND_KWARGS,
+        token_url=TOKEN_URL,
+        client_id='11111111-1111-1111-1111-111111111111',
+        client_secret='test-secret-value',  # noqa: S105
         description='some metadata that may be passed',  # type: ignore[call-arg]
     )
 

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -9,6 +9,7 @@ from awx_plugins.credentials import (
     oauth2_client_credentials as oauth2_mod,
 )
 
+
 TOKEN_URL = (
     'https://login.microsoftonline.com'
     '/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token'

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -388,6 +388,26 @@ def test_timeout_error(
         call_backend()
 
 
+def test_generic_request_exception(
+    mocker: MockerFixture,
+    call_backend: _BackendCaller,
+) -> None:
+    """Test that other RequestException subclasses are wrapped."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        side_effect=oauth2_mod.requests.exceptions.TooManyRedirects(
+            'Exceeded 30 redirects',
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r'Failed requesting token from endpoint',
+    ):
+        call_backend()
+
+
 def test_discarded_kwargs_are_ignored(
     mocker: MockerFixture,
 ) -> None:

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -14,8 +14,11 @@ TOKEN_URL = (
     'https://login.microsoftonline.com'
     '/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token'
 )
-CLIENT_ID = '11111111-1111-1111-1111-111111111111'
-CLIENT_SECRET = 'test-secret-value'  # noqa: S105
+_COMMON_BACKEND_KWARGS: dict[str, str] = {
+    'token_url': TOKEN_URL,
+    'client_id': '11111111-1111-1111-1111-111111111111',
+    'client_secret': 'test-secret-value',  # noqa: S105
+}
 ADO_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default'
 FAKE_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.fake.token'  # noqa: S105
 
@@ -104,9 +107,7 @@ def test_successful_token_fetch(mocker: MockerFixture) -> None:
     )
 
     token = oauth2_mod.oauth2_client_credentials_backend(
-        token_url=TOKEN_URL,
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
+        **_COMMON_BACKEND_KWARGS,
         scope=ADO_SCOPE,
     )
 
@@ -125,16 +126,15 @@ def test_request_includes_grant_type(mocker: MockerFixture) -> None:
     )
 
     oauth2_mod.oauth2_client_credentials_backend(
-        token_url=TOKEN_URL,
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
+        **_COMMON_BACKEND_KWARGS,
         scope=ADO_SCOPE,
     )
 
     call_kwargs = mock_post.call_args
-    assert call_kwargs[1]['data']['grant_type'] == 'client_credentials'
-    assert call_kwargs[1]['data']['client_id'] == CLIENT_ID
-    assert call_kwargs[1]['data']['scope'] == ADO_SCOPE
+    post_data = call_kwargs[1]['data']
+    assert post_data['grant_type'] == 'client_credentials'
+    assert post_data['client_id'] == _COMMON_BACKEND_KWARGS['client_id']
+    assert post_data['scope'] == ADO_SCOPE
 
 
 @pytest.mark.parametrize(
@@ -158,11 +158,7 @@ def test_no_scope_omits_scope_from_request(
         ),
     )
 
-    kwargs: dict[str, str] = {
-        'token_url': TOKEN_URL,
-        'client_id': CLIENT_ID,
-        'client_secret': CLIENT_SECRET,
-    }
+    kwargs = dict(_COMMON_BACKEND_KWARGS)
     if scope_value is not None:
         kwargs['scope'] = scope_value
 
@@ -206,9 +202,7 @@ def test_works_with_various_providers(
     )
 
     token = oauth2_mod.oauth2_client_credentials_backend(
-        token_url=token_url,
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
+        **{**_COMMON_BACKEND_KWARGS, 'token_url': token_url},
     )
 
     assert token == FAKE_TOKEN
@@ -259,9 +253,7 @@ def test_http_errors_raise_value_error(
 
     with pytest.raises(ValueError, match=error_pattern):
         oauth2_mod.oauth2_client_credentials_backend(
-            token_url=TOKEN_URL,
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
+            **_COMMON_BACKEND_KWARGS,
         )
 
 
@@ -281,9 +273,7 @@ def test_non_json_error_response(mocker: MockerFixture) -> None:
         match=r'HTTP 503.*Service Unavailable',
     ):
         oauth2_mod.oauth2_client_credentials_backend(
-            token_url=TOKEN_URL,
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
+            **_COMMON_BACKEND_KWARGS,
         )
 
 
@@ -308,9 +298,7 @@ def test_missing_access_token_in_response(
         match=r'did not contain an access_token',
     ):
         oauth2_mod.oauth2_client_credentials_backend(
-            token_url=TOKEN_URL,
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
+            **_COMMON_BACKEND_KWARGS,
         )
 
 
@@ -332,9 +320,7 @@ def test_non_dict_json_success_response(
         match=r'did not contain an access_token',
     ):
         oauth2_mod.oauth2_client_credentials_backend(
-            token_url=TOKEN_URL,
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
+            **_COMMON_BACKEND_KWARGS,
         )
 
 
@@ -357,9 +343,7 @@ def test_non_dict_json_error_response(
         match=r'HTTP 400.*Bad Request',
     ):
         oauth2_mod.oauth2_client_credentials_backend(
-            token_url=TOKEN_URL,
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
+            **_COMMON_BACKEND_KWARGS,
         )
 
 
@@ -381,9 +365,7 @@ def test_unparseable_json_success_response(
         match=r'did not contain an access_token',
     ):
         oauth2_mod.oauth2_client_credentials_backend(
-            token_url=TOKEN_URL,
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
+            **_COMMON_BACKEND_KWARGS,
         )
 
 
@@ -402,9 +384,7 @@ def test_connection_error(mocker: MockerFixture) -> None:
         match=r'Could not connect to token endpoint',
     ):
         oauth2_mod.oauth2_client_credentials_backend(
-            token_url=TOKEN_URL,
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
+            **_COMMON_BACKEND_KWARGS,
         )
 
 
@@ -423,9 +403,7 @@ def test_timeout_error(mocker: MockerFixture) -> None:
         match=r'Timed out requesting token',
     ):
         oauth2_mod.oauth2_client_credentials_backend(
-            token_url=TOKEN_URL,
-            client_id=CLIENT_ID,
-            client_secret=CLIENT_SECRET,
+            **_COMMON_BACKEND_KWARGS,
         )
 
 
@@ -441,9 +419,7 @@ def test_discarded_kwargs_are_ignored(mocker: MockerFixture) -> None:
     )
 
     token = oauth2_mod.oauth2_client_credentials_backend(
-        token_url=TOKEN_URL,
-        client_id=CLIENT_ID,
-        client_secret=CLIENT_SECRET,
+        **_COMMON_BACKEND_KWARGS,
         description='some metadata that may be passed',  # type: ignore[call-arg]
     )
 

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -1,6 +1,6 @@
 """Tests for the OAuth2 Client Credentials Token credential plugin."""
 
-from typing import Any
+import http
 
 import pytest
 from pytest_mock import MockerFixture
@@ -8,7 +8,6 @@ from pytest_mock import MockerFixture
 from awx_plugins.credentials import (
     oauth2_client_credentials as oauth2_mod,
 )
-
 
 TOKEN_URL = (
     'https://login.microsoftonline.com'
@@ -23,17 +22,18 @@ FAKE_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.fake.token'  # noqa: S105
 class _FakeResponse:
     """Minimal stand-in for ``requests.Response``."""
 
-    def __init__(
+    def __init__(  # noqa: ANN101
         self,
         status_code: int,
-        json_data: dict[str, Any] | None = None,
+        json_data: object = None,
         text: str = '',
     ) -> None:
         self.status_code = status_code
         self._json_data = json_data
         self.text = text
 
-    def json(self) -> dict[str, Any]:
+    def json(self) -> object:  # noqa: ANN101
+        """Return the stored JSON payload or raise."""
         if self._json_data is None:
             raise ValueError('No JSON')
         return self._json_data
@@ -93,7 +93,7 @@ def test_successful_token_fetch(mocker: MockerFixture) -> None:
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=200,
+            status_code=http.HTTPStatus.OK,
             json_data={
                 'access_token': FAKE_TOKEN,
                 'token_type': 'Bearer',
@@ -118,7 +118,7 @@ def test_request_includes_grant_type(mocker: MockerFixture) -> None:
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=200,
+            status_code=http.HTTPStatus.OK,
             json_data={'access_token': FAKE_TOKEN},
         ),
     )
@@ -152,12 +152,12 @@ def test_no_scope_omits_scope_from_request(
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=200,
+            status_code=http.HTTPStatus.OK,
             json_data={'access_token': FAKE_TOKEN},
         ),
     )
 
-    kwargs: dict[str, Any] = {
+    kwargs: dict[str, str] = {
         'token_url': TOKEN_URL,
         'client_id': CLIENT_ID,
         'client_secret': CLIENT_SECRET,
@@ -199,7 +199,7 @@ def test_works_with_various_providers(
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=200,
+            status_code=http.HTTPStatus.OK,
             json_data={'access_token': FAKE_TOKEN},
         ),
     )
@@ -221,7 +221,7 @@ def test_works_with_various_providers(
     ),
     (
         pytest.param(
-            401,
+            http.HTTPStatus.UNAUTHORIZED,
             {
                 'error': 'invalid_client',
                 'error_description': 'Invalid client secret provided.',
@@ -230,7 +230,7 @@ def test_works_with_various_providers(
             id='invalid-credentials',
         ),
         pytest.param(
-            400,
+            http.HTTPStatus.BAD_REQUEST,
             {
                 'error': 'invalid_request',
                 'error_description': 'Tenant not found.',
@@ -270,7 +270,7 @@ def test_non_json_error_response(mocker: MockerFixture) -> None:
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=503,
+            status_code=http.HTTPStatus.SERVICE_UNAVAILABLE,
             text='Service Unavailable',
         ),
     )
@@ -294,7 +294,7 @@ def test_missing_access_token_in_response(
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=200,
+            status_code=http.HTTPStatus.OK,
             json_data={
                 'token_type': 'Bearer',
                 'expires_in': 3600,
@@ -321,7 +321,7 @@ def test_non_dict_json_success_response(
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=200,
+            status_code=http.HTTPStatus.OK,
             json_data=['not', 'a', 'dict'],
         ),
     )
@@ -345,7 +345,7 @@ def test_non_dict_json_error_response(
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=400,
+            status_code=http.HTTPStatus.BAD_REQUEST,
             json_data=['not', 'a', 'dict'],
             text='Bad Request',
         ),
@@ -410,7 +410,7 @@ def test_discarded_kwargs_are_ignored(mocker: MockerFixture) -> None:
         oauth2_mod.requests,
         'post',
         return_value=_FakeResponse(
-            status_code=200,
+            status_code=http.HTTPStatus.OK,
             json_data={'access_token': FAKE_TOKEN},
         ),
     )
@@ -419,7 +419,7 @@ def test_discarded_kwargs_are_ignored(mocker: MockerFixture) -> None:
         token_url=TOKEN_URL,
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
-        description='some metadata AWX may pass',
+        description='some metadata that may be passed',  # type: ignore[call-arg]
     )
 
     assert token == FAKE_TOKEN

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -313,6 +313,55 @@ def test_missing_access_token_in_response(
         )
 
 
+def test_non_dict_json_success_response(
+    mocker: MockerFixture,
+) -> None:
+    """Test handling of a 200 response whose JSON is not an object."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=200,
+            json_data=['not', 'a', 'dict'],
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r'did not contain an access_token',
+    ):
+        oauth2_mod.oauth2_client_credentials_backend(
+            token_url=TOKEN_URL,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+
+def test_non_dict_json_error_response(
+    mocker: MockerFixture,
+) -> None:
+    """Test handling of an error response whose JSON is not an object."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=400,
+            json_data=['not', 'a', 'dict'],
+            text='Bad Request',
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r'HTTP 400.*Bad Request',
+    ):
+        oauth2_mod.oauth2_client_credentials_backend(
+            token_url=TOKEN_URL,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+
 def test_connection_error(mocker: MockerFixture) -> None:
     """Test that connection errors are wrapped in ValueError."""
     mocker.patch.object(

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -1,0 +1,375 @@
+"""Tests for the OAuth2 Client Credentials Token credential plugin."""
+
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from awx_plugins.credentials import (
+    oauth2_client_credentials as oauth2_mod,
+)
+
+TOKEN_URL = (
+    'https://login.microsoftonline.com'
+    '/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token'
+)
+CLIENT_ID = '11111111-1111-1111-1111-111111111111'
+CLIENT_SECRET = 'test-secret-value'  # noqa: S105
+ADO_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default'
+FAKE_TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.fake.token'  # noqa: S105
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``requests.Response``."""
+
+    def __init__(
+        self,
+        status_code: int,
+        json_data: dict[str, Any] | None = None,
+        text: str = '',
+    ) -> None:
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+
+    def json(self) -> dict[str, Any]:
+        if self._json_data is None:
+            raise ValueError('No JSON')
+        return self._json_data
+
+
+def test_plugin_name() -> None:
+    """Verify the plugin has the expected human-readable name."""
+    expected = 'OAuth2 Client Credentials Token Lookup'
+    assert oauth2_mod.oauth2_client_credentials_plugin.name == expected
+
+
+def test_plugin_inputs_required_fields() -> None:
+    """Verify that all three required input fields are declared."""
+    field_ids = [
+        field['id']
+        for field in oauth2_mod.oauth2_client_credentials_inputs['fields']
+    ]
+    assert 'token_url' in field_ids
+    assert 'client_id' in field_ids
+    assert 'client_secret' in field_ids
+
+
+def test_client_secret_is_marked_secret() -> None:
+    """Ensure the client_secret field has the secret flag set."""
+    secret_field = next(
+        field
+        for field in oauth2_mod.oauth2_client_credentials_inputs['fields']
+        if field['id'] == 'client_secret'
+    )
+    assert secret_field['secret'] is True
+
+
+def test_metadata_has_scope() -> None:
+    """Verify scope is available as a metadata field."""
+    metadata_ids = [
+        meta['id']
+        for meta in oauth2_mod.oauth2_client_credentials_inputs['metadata']
+    ]
+    assert 'scope' in metadata_ids
+
+
+def test_plugin_backend_is_callable() -> None:
+    """Ensure the backend function can be called."""
+    assert callable(oauth2_mod.oauth2_client_credentials_plugin.backend)
+
+
+def test_plugin_has_description() -> None:
+    """Verify the plugin has a non-empty description."""
+    desc = oauth2_mod.oauth2_client_credentials_plugin.plugin_description
+    assert desc
+    assert 'OAuth2' in desc
+
+
+def test_successful_token_fetch(mocker: MockerFixture) -> None:
+    """Test a successful token retrieval."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=200,
+            json_data={
+                'access_token': FAKE_TOKEN,
+                'token_type': 'Bearer',
+                'expires_in': 3600,
+            },
+        ),
+    )
+
+    token = oauth2_mod.oauth2_client_credentials_backend(
+        token_url=TOKEN_URL,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        scope=ADO_SCOPE,
+    )
+
+    assert token == FAKE_TOKEN
+
+
+def test_request_includes_grant_type(mocker: MockerFixture) -> None:
+    """Verify the POST body includes grant_type=client_credentials."""
+    mock_post = mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=200,
+            json_data={'access_token': FAKE_TOKEN},
+        ),
+    )
+
+    oauth2_mod.oauth2_client_credentials_backend(
+        token_url=TOKEN_URL,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        scope=ADO_SCOPE,
+    )
+
+    call_kwargs = mock_post.call_args
+    assert call_kwargs[1]['data']['grant_type'] == 'client_credentials'
+    assert call_kwargs[1]['data']['client_id'] == CLIENT_ID
+    assert call_kwargs[1]['data']['scope'] == ADO_SCOPE
+
+
+@pytest.mark.parametrize(
+    'scope_value',
+    (
+        pytest.param('', id='empty-string'),
+        pytest.param(None, id='none-via-default'),
+    ),
+)
+def test_no_scope_omits_scope_from_request(
+    mocker: MockerFixture,
+    scope_value: str | None,
+) -> None:
+    """Verify that an empty or missing scope is not sent."""
+    mock_post = mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=200,
+            json_data={'access_token': FAKE_TOKEN},
+        ),
+    )
+
+    kwargs: dict[str, Any] = {
+        'token_url': TOKEN_URL,
+        'client_id': CLIENT_ID,
+        'client_secret': CLIENT_SECRET,
+    }
+    if scope_value is not None:
+        kwargs['scope'] = scope_value
+
+    oauth2_mod.oauth2_client_credentials_backend(**kwargs)
+
+    post_data = mock_post.call_args[1]['data']
+    assert 'scope' not in post_data
+
+
+@pytest.mark.parametrize(
+    'token_url',
+    (
+        pytest.param(
+            'https://login.microsoftonline.com'
+            '/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token',
+            id='entra-id',
+        ),
+        pytest.param(
+            'https://keycloak.example.com'
+            '/realms/myrealm/protocol/openid-connect/token',
+            id='keycloak',
+        ),
+        pytest.param(
+            'https://dev-12345.okta.com/oauth2/default/v1/token',
+            id='okta',
+        ),
+    ),
+)
+def test_works_with_various_providers(
+    mocker: MockerFixture,
+    token_url: str,
+) -> None:
+    """Verify the plugin works with different OAuth2 provider URLs."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=200,
+            json_data={'access_token': FAKE_TOKEN},
+        ),
+    )
+
+    token = oauth2_mod.oauth2_client_credentials_backend(
+        token_url=token_url,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+    )
+
+    assert token == FAKE_TOKEN
+
+
+@pytest.mark.parametrize(
+    (
+        'status_code',
+        'response_body',
+        'error_pattern',
+    ),
+    (
+        pytest.param(
+            401,
+            {
+                'error': 'invalid_client',
+                'error_description': 'Invalid client secret provided.',
+            },
+            r'Token request failed.*HTTP 401.*Invalid client secret',
+            id='invalid-credentials',
+        ),
+        pytest.param(
+            400,
+            {
+                'error': 'invalid_request',
+                'error_description': 'Tenant not found.',
+            },
+            r'Tenant not found',
+            id='bad-request',
+        ),
+    ),
+)
+def test_http_errors_raise_value_error(
+    mocker: MockerFixture,
+    status_code: int,
+    response_body: dict[str, str],
+    error_pattern: str,
+) -> None:
+    """Test that HTTP errors are converted to ValueError."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=status_code,
+            json_data=response_body,
+        ),
+    )
+
+    with pytest.raises(ValueError, match=error_pattern):
+        oauth2_mod.oauth2_client_credentials_backend(
+            token_url=TOKEN_URL,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+
+def test_non_json_error_response(mocker: MockerFixture) -> None:
+    """Test handling of non-JSON error responses."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=503,
+            text='Service Unavailable',
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r'HTTP 503.*Service Unavailable',
+    ):
+        oauth2_mod.oauth2_client_credentials_backend(
+            token_url=TOKEN_URL,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+
+def test_missing_access_token_in_response(
+    mocker: MockerFixture,
+) -> None:
+    """Test handling of responses without an access_token field."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=200,
+            json_data={
+                'token_type': 'Bearer',
+                'expires_in': 3600,
+            },
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r'did not contain an access_token',
+    ):
+        oauth2_mod.oauth2_client_credentials_backend(
+            token_url=TOKEN_URL,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+
+def test_connection_error(mocker: MockerFixture) -> None:
+    """Test that connection errors are wrapped in ValueError."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        side_effect=oauth2_mod.requests.exceptions.ConnectionError(
+            'Connection refused',
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r'Could not connect to token endpoint',
+    ):
+        oauth2_mod.oauth2_client_credentials_backend(
+            token_url=TOKEN_URL,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+
+def test_timeout_error(mocker: MockerFixture) -> None:
+    """Test that timeout errors are wrapped in ValueError."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        side_effect=oauth2_mod.requests.exceptions.Timeout(
+            'Read timed out',
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r'Timed out requesting token',
+    ):
+        oauth2_mod.oauth2_client_credentials_backend(
+            token_url=TOKEN_URL,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+
+def test_discarded_kwargs_are_ignored(mocker: MockerFixture) -> None:
+    """Verify unexpected kwargs don't break the backend."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=200,
+            json_data={'access_token': FAKE_TOKEN},
+        ),
+    )
+
+    token = oauth2_mod.oauth2_client_credentials_backend(
+        token_url=TOKEN_URL,
+        client_id=CLIENT_ID,
+        client_secret=CLIENT_SECRET,
+        description='some metadata AWX may pass',
+    )
+
+    assert token == FAKE_TOKEN

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -323,6 +323,16 @@ def test_http_errors_raise_value_error(
             'not json at all',
             id='unparseable-json',
         ),
+        pytest.param(
+            {'access_token': None},
+            '',
+            id='null-access-token',
+        ),
+        pytest.param(
+            {'access_token': ''},
+            '',
+            id='empty-access-token',
+        ),
     ),
 )
 def test_malformed_success_response(
@@ -347,6 +357,24 @@ def test_malformed_success_response(
         match=r'did not contain an access_token',
     ):
         call_backend()
+
+
+def test_rejects_non_https_token_url(
+    mocker: MockerFixture,
+    call_backend: _BackendCaller,
+) -> None:
+    """Verify non-https token endpoints are rejected before posting."""
+    mock_post = mocker.patch.object(oauth2_mod.requests, 'post')
+
+    with pytest.raises(ValueError, match=r'must use https'):
+        call_backend(
+            token_url=(
+                'http://login.microsoftonline.com'
+                '/00000000-0000-0000-0000-000000000000/oauth2/v2.0/token'
+            ),
+        )
+
+    mock_post.assert_not_called()
 
 
 def test_connection_error(

--- a/tests/oauth2_client_credentials_test.py
+++ b/tests/oauth2_client_credentials_test.py
@@ -363,6 +363,30 @@ def test_non_dict_json_error_response(
         )
 
 
+def test_unparseable_json_success_response(
+    mocker: MockerFixture,
+) -> None:
+    """Test handling of a 200 response with non-JSON body."""
+    mocker.patch.object(
+        oauth2_mod.requests,
+        'post',
+        return_value=_FakeResponse(
+            status_code=http.HTTPStatus.OK,
+            text='not json at all',
+        ),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r'did not contain an access_token',
+    ):
+        oauth2_mod.oauth2_client_credentials_backend(
+            token_url=TOKEN_URL,
+            client_id=CLIENT_ID,
+            client_secret=CLIENT_SECRET,
+        )
+
+
 def test_connection_error(mocker: MockerFixture) -> None:
     """Test that connection errors are wrapped in ValueError."""
     mocker.patch.object(


### PR DESCRIPTION
Resolves: AAPRFE-955

## Summary

Add a new credential plugin (`oauth2_client_credentials`) that fetches a short-lived bearer token using the OAuth 2.0 `client_credentials` grant. This enables authentication with services that require OAuth2 tokens without storing long-lived credentials.

Closes #184

## How it works

1. An administrator creates an "OAuth2 Client Credentials Token Lookup" credential with:
   - **Token Endpoint URL** (e.g. `https://login.microsoftonline.com/<tenant>/oauth2/v2.0/token`)
   - **Client ID** (application/service principal identifier)
   - **Client Secret**
2. A target credential (e.g. Source Control) links its password field to the OAuth2 credential and optionally specifies a **scope** (e.g. `499b84ac-1321-427f-aa17-267ca6975798/.default` for Azure DevOps).
3. On every credential resolution, the plugin POSTs to the token endpoint and returns the `access_token` from the response.

Works with any compliant OAuth2 provider including Microsoft Entra ID, Keycloak, Okta, and Auth0.

## Changes

| File | Description |
|------|-------------|
| `src/awx_plugins/credentials/oauth2_client_credentials.py` | New plugin module with backend function and plugin definition |
| `tests/oauth2_client_credentials_test.py` | Unit tests covering success path, error handling, scope omission, multiple providers, and discarded kwargs |
| `pyproject.toml` | Entry point under `awx_plugins.credentials` and optional dependency group `credentials-oauth2-client-credentials` |
| `tests/importable_test.py` | Added to entry point smoke test tuple |
| `docs/spelling_wordlist.txt` | Added "Entra" and "Keycloak" |

## Primary use case: Azure DevOps project sync

Azure DevOps has deprecated PATs and SSH keys for service-to-service authentication in favour of Microsoft Entra ID service principals. This plugin enables:

1. Create an Entra ID App Registration with a client secret.
2. Add the Service Principal to the ADO organisation.
3. Create an OAuth2 credential with the Entra token endpoint, client ID, and secret.
4. Link an SCM credential's password to the OAuth2 credential (username: `x-token`, scope: `499b84ac-1321-427f-aa17-267ca6975798/.default`).
5. Project sync automatically resolves a fresh Entra token on every run.

## Testing

- Unit tests follow the existing plugin test patterns (`pytest` + `pytest-mock`).
- Manually verified end-to-end: OAuth2 credential -> linked SCM credential -> successful Azure DevOps project sync using an Entra ID service principal.

Signed-off-by: Alexey Masolov <amasolov@redhat.com>

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OAuth2 Client Credentials credential plugin, including a matching optional dependency group for OAuth2 client-credentials usage.
* **Tests**
  * Added a dedicated test suite for the plugin, validating metadata, request payload construction, scope handling, and robust error/timeout handling.
* **Documentation**
  * Updated the spelling wordlist and adjusted Sphinx nitpicky settings to avoid unresolved-reference warnings for the HTTP response type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->