### PR TITLE
fix: accept unknown keyword arguments in azure_keyvault_backend

### DIFF
--- a/src/awx_plugins/credentials/azure_kv.py
+++ b/src/awx_plugins/credentials/azure_kv.py
@@ -128,6 +128,7 @@ def azure_keyvault_backend(  # noqa: WPS211
     tenant: str = '',
     secret_field: str,
     secret_version: str = '',
+    **kwargs: str,
 ) -> str | None:
     """Get a credential and retrieve a secret from an Azure Key Vault.
 

--- a/tests/azure_kv_test.py
+++ b/tests/azure_kv_test.py
@@ -138,3 +138,25 @@ def test_azure_kv_valid_auth(
         secret_version='',
     )
     assert keyvault_secret == 'test-secret'
+
+
+def test_azure_kv_with_cloud_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test that cloud_name input field does not cause a TypeError."""
+    monkeypatch.setattr(
+        azure_kv,
+        'SecretClient',
+        _FakeSecretClient,
+    )
+
+    keyvault_secret = azure_kv.azure_keyvault_backend(
+        url='https://keyvault.test',
+        client='client-id',
+        secret='client-secret',
+        tenant='tenant-id',
+        secret_field='secret',
+        secret_version='',
+        cloud_name='AzureCloud',
+    )
+    assert keyvault_secret == 'test-secret'


### PR DESCRIPTION
## Summary
- Add `**kwargs` to `azure_keyvault_backend()` to accept extra input fields like `cloud_name`
- The `cloud_name` field is defined in `azure_keyvault_inputs` but was dropped from the function signature in cf49fd05bb, causing a `TypeError` when AWX resolves credential input sources
- Add test to verify `cloud_name` is accepted without error

## Error
```
TypeError: azure_keyvault_backend() got an unexpected keyword argument 'cloud_name'
```

When a project credential uses an Azure Key Vault external credential with `cloud_name` set, updating the project via the API (`PATCH /api/controller/v2/projects/<id>/`) triggers `clean_credential` → `get_input` → `get_input_value` which passes all input fields (including `cloud_name`) to the backend function.

## Root Cause
Regression introduced in cf49fd05bba6e4a05953fc4015ad0d4ad7e18c33 which replaced the original `**kwargs` signature with explicit typed parameters but omitted `cloud_name`.

## Test plan
- [x] Add test that passes `cloud_name` kwarg to `azure_keyvault_backend()`
- [ ] Verify PATCH to a project with Azure Key Vault credential input source no longer returns 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Azure Key Vault credential backend now properly supports environment-specific configuration parameters, including cloud_name. Previously, passing these additional parameters would result in errors. The backend now accepts these optional parameters, enabling users to properly configure different cloud environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->