### PR TITLE
`secret` not allowed for `boolean` type (`verify_ssl`).

### DIFF
--- a/src/awx_plugins/credentials/plugins.py
+++ b/src/awx_plugins/credentials/plugins.py
@@ -745,7 +745,6 @@ controller = ManagedCredentialType(
                 'id': 'verify_ssl',
                 'label': gettext_noop('Verify SSL'),
                 'type': 'boolean',
-                'secret': False,
             },
             {
                 'id': 'request_timeout',


### PR DESCRIPTION
While testing https://github.com/ansible/awx-plugins/pull/188, I found this issue. Basically, `secret` is not an allowed value (`true` or `false`) for a `boolean` type.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the SSL verification field in credential configuration by explicitly defining it as a boolean. This ensures the "Verify SSL" option behaves consistently in credential forms and when credentials are injected into workflows, improving validation and preventing mismatches between configuration and runtime use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->