### PR TITLE
Add Akeyless credential plugins, with OIDC workload identity support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -119,8 +119,7 @@ per-file-ignores =
 
   # WPS202: two-plugin module (secret store + SSH) with Protocol types, TypedDicts,
   # and multiple helpers per plugin; could be split into a sub-package later.
-  # WPS238: auth + fetch each wrap ApiException and ValueError into RuntimeError.
-  src/awx_plugins/credentials/akeyless.py: WPS202, WPS238
+  src/awx_plugins/credentials/akeyless.py: WPS202
 
   # The following ignores must be fixed and the entries removed from this config:
   src/awx_plugins/credentials/aim.py: ANN003, ANN201, B950, CCR001, D100, D103, LN001, Q003, WPS210, WPS221, WPS223, WPS231, WPS336, WPS432

--- a/.flake8
+++ b/.flake8
@@ -117,6 +117,11 @@ per-file-ignores =
   # additionally test docstrings don't need param lists (DAR, DCO020):
   tests/**.py: DAR, DCO020, S101, S105, S108, S404, S603, WPS202, WPS210, WPS430, WPS436, WPS441, WPS442, WPS450
 
+  # WPS202: two-plugin module (secret store + SSH) with Protocol types, TypedDicts,
+  # and multiple helpers per plugin; could be split into a sub-package later.
+  # WPS238: auth + fetch each wrap ApiException and ValueError into RuntimeError.
+  src/awx_plugins/credentials/akeyless.py: WPS202, WPS238
+
   # The following ignores must be fixed and the entries removed from this config:
   src/awx_plugins/credentials/aim.py: ANN003, ANN201, B950, CCR001, D100, D103, LN001, Q003, WPS210, WPS221, WPS223, WPS231, WPS336, WPS432
   src/awx_plugins/credentials/aws_secretsmanager.py: ANN003, ANN201, D100, D103, WPS111, WPS210, WPS329, WPS529

--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,4 @@ pip-selfcheck.json
 
 # lockfile scripts
 !/bin/
+.python-version

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -62,6 +62,12 @@ warn_unused_ignores = true
 # crashes with some decorators like `@functools.cache`:
 disallow_any_expr = false
 
+[mypy-awx_plugins.credentials.akeyless]
+# gettext_noop() from the interfaces package returns Any:
+disallow_any_expr = false
+# _plugin.CertFiles is untyped in the interfaces package:
+disallow_untyped_calls = false
+
 [mypy-awx_plugins.credentials.aws_secretsmanager]
 # crashes with some decorators like `@functools.cache`:
 disallow_any_expr = false
@@ -111,6 +117,8 @@ disallow_any_expr = false
 disallow_any_expr = false
 # fails on `@hypothesis.given()`:
 disallow_any_decorated = false
+# fixture return types like `Callable[..., object]` use `...` as Any:
+disallow_any_explicit = false
 
 # It is sometimes necessary to access "officially-private" attributes in our
 # own tests for the purposes of assertion, mocking and spying on objects. And
@@ -120,3 +128,8 @@ disallow_any_decorated = false
 #
 # [1] https://til.codeinthehole.com/posts/how-to-handle-convenience-imports-with-mypy/
 disable_error_code = attr-defined
+
+[mypy-tests.akeyless_test]
+# Mock API objects are typed as `object`; test kwargs use generic dict
+# rather than the specific TypedDicts the plugin functions expect:
+disable_error_code = attr-defined, arg-type

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -323,6 +323,7 @@ repos:
     - pytest-mock  # needed by pylint-pytest since it picks up pytest's args
     - pytest-subtests  # needed by pylint-pytest since it picks up pytest's args
     - pytest-xdist  # needed by pylint-pytest since it picks up pytest's args
+    - akeyless >= 5.0.8  # needed by credentials.akeyless and its tests
     - python-dsv-sdk  # needed by credentials.dsv, credentials.thycotic_dsv
     - PyYAML  # needed by credentials.injectors, inventory.plugins
     - Sphinx  # needed by the Sphinx extension stub

--- a/.pylintrc.toml
+++ b/.pylintrc.toml
@@ -106,7 +106,10 @@ py-version = "3.11"
 # source root is an absolute path or a path relative to the current working
 # directory used to determine a package namespace for modules located under the
 # source root.
-# source-roots =
+# Complements init-hook: init-hook adjusts runtime sys.path while source-roots
+# controls pylint's static module discovery, preventing it from resolving
+# akeyless.py as the top-level 'akeyless' package instead of the SDK.
+source-roots = ["src"]
 
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -173,6 +173,9 @@ testing = [
   "S101",    # Allow use of `assert` in test files
   "S105",    # hardcoded-password-string
   "S106",    # hardcoded-password-func-arg
+  "S107",    # hardcoded-password-func-default: test helper factories use
+             # credential-like param names (token, secret_data) as configurable
+             # defaults — these are never real credentials
   "S108",    # tmp dirs
   "S404",    # Allow importing 'subprocess' module to testing call external tools needed by these hooks
   "S603",    # subprocess calls

--- a/_type_stubs/akeyless/__init__.pyi
+++ b/_type_stubs/akeyless/__init__.pyi
@@ -1,0 +1,72 @@
+from collections.abc import Mapping
+
+class Configuration:
+    host: str
+    ssl_ca_cert: str | None
+    verify_ssl: bool
+    def __init__(self, host: str = ...) -> None: ...
+
+class ApiClient:
+    user_agent: str
+    default_headers: dict[str, str]
+    def __init__(self, configuration: Configuration | None = ...) -> None: ...
+
+class Auth:
+    access_id: str
+    access_key: str
+    def __init__(
+        self,
+        *,
+        access_id: str = ...,
+        access_key: str = ...,
+    ) -> None: ...
+
+class AuthOutput:
+    token: str | None
+
+class StaticSecretInfo:
+    format: str
+
+class ItemGeneralInfo:
+    static_secret_info: StaticSecretInfo
+
+class DescribeItemOutput:
+    item_type: str
+    item_sub_type: str
+    item_general_info: ItemGeneralInfo
+
+class DescribeItem:
+    name: str
+    token: str
+    def __init__(
+        self,
+        *,
+        name: str = ...,
+        token: str = ...,
+    ) -> None: ...
+
+class GetSecretValue:
+    names: list[str]
+    token: str
+    def __init__(
+        self,
+        *,
+        names: list[str] = ...,
+        token: str = ...,
+    ) -> None: ...
+
+class GetSSHCertificateOutput:
+    data: str | None
+
+class V2Api:
+    def __init__(self, api_client: ApiClient | None = ...) -> None: ...
+    def auth(self, auth: Auth) -> AuthOutput: ...
+    def describe_item(self, req: DescribeItem) -> DescribeItemOutput: ...
+    def get_secret_value(
+        self,
+        req: GetSecretValue,
+    ) -> Mapping[str, str]: ...
+    def get_ssh_certificate(
+        self,
+        req: object,
+    ) -> GetSSHCertificateOutput: ...

--- a/_type_stubs/akeyless/__init__.pyi
+++ b/_type_stubs/akeyless/__init__.pyi
@@ -14,11 +14,15 @@ class ApiClient:
 class Auth:
     access_id: str
     access_key: str
+    access_type: str
+    jwt: str
     def __init__(
         self,
         *,
         access_id: str = ...,
         access_key: str = ...,
+        access_type: str = ...,
+        jwt: str = ...,
     ) -> None: ...
 
 class AuthOutput:

--- a/_type_stubs/akeyless/models/get_ssh_certificate.pyi
+++ b/_type_stubs/akeyless/models/get_ssh_certificate.pyi
@@ -1,0 +1,15 @@
+class GetSSHCertificate:
+    token: str
+    cert_issuer_name: str
+    cert_username: str
+    ttl: int | None
+    public_key_data: str
+    def __init__(
+        self,
+        *,
+        token: str = ...,
+        cert_issuer_name: str = ...,
+        cert_username: str = ...,
+        ttl: int | None = ...,
+        public_key_data: str = ...,
+    ) -> None: ...

--- a/_type_stubs/akeyless/rest.pyi
+++ b/_type_stubs/akeyless/rest.pyi
@@ -1,0 +1,9 @@
+class ApiException(Exception):  # noqa: N818
+    status: int
+    reason: str
+    def __init__(
+        self,
+        status: int = ...,
+        reason: str = ...,
+        http_resp: object | None = ...,
+    ) -> None: ...

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -240,6 +240,12 @@ nitpick_ignore = [
     ('py:class', '_PT'),  # generic ParamSpec type variable
     ('py:class', '_contextvars.ContextVar'),  # unresolved context var type
     ('py:class', 'EnvVarsType'),
+    # Akeyless SDK types: auto-generated from OpenAPI
+    # without type annotations or .pyi stubs
+    ('py:class', 'akeyless.models.auth.Auth'),
+    ('py:class', 'akeyless.models.describe_item.DescribeItem'),
+    ('py:class', 'akeyless.models.get_secret_value.GetSecretValue'),
+    ('py:class', 'akeyless.models.get_ssh_certificate.GetSSHCertificate'),
 ]
 
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,3 +1,4 @@
+Akeyless
 Ansible
 Approle
 async

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ centrify_vault_kv = "awx_plugins.credentials.centrify_vault:centrify_plugin"
 thycotic_dsv = "awx_plugins.credentials.dsv:dsv_plugin"
 thycotic_tss = "awx_plugins.credentials.tss:tss_plugin"
 aws_secretsmanager_credential = "awx_plugins.credentials.aws_secretsmanager:aws_secretmanager_plugin"
+akeyless = "awx_plugins.credentials.akeyless:akeyless_plugin"
+akeyless_ssh = "awx_plugins.credentials.akeyless:akeyless_ssh_plugin"
 github_app_lookup = "awx_plugins.credentials.github_app:github_app_lookup"
 
 [project.entry-points."awx_plugins.managed_credentials"] # new entry points group name
@@ -188,6 +190,14 @@ credentials-thycotic-tss = [
 credentials-aws-secretsmanager-credential = [
   "awx_plugins.interfaces",
   "boto3",
+]
+credentials-akeyless = [
+  "awx_plugins.interfaces",
+  "akeyless >= 5.0.8",
+]
+credentials-akeyless-ssh = [
+  "awx_plugins.interfaces",
+  "akeyless >= 5.0.8",
 ]
 inventory-azure-rm = [
   "awx_plugins.interfaces",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,8 @@ thycotic_tss = "awx_plugins.credentials.tss:tss_plugin"
 aws_secretsmanager_credential = "awx_plugins.credentials.aws_secretsmanager:aws_secretmanager_plugin"
 akeyless = "awx_plugins.credentials.akeyless:akeyless_plugin"
 akeyless_ssh = "awx_plugins.credentials.akeyless:akeyless_ssh_plugin"
+akeyless-oidc = "awx_plugins.credentials.akeyless:akeyless_oidc_plugin"
+akeyless-ssh-oidc = "awx_plugins.credentials.akeyless:akeyless_ssh_oidc_plugin"
 github_app_lookup = "awx_plugins.credentials.github_app:github_app_lookup"
 
 [project.entry-points."awx_plugins.managed_credentials"] # new entry points group name
@@ -196,6 +198,14 @@ credentials-akeyless = [
   "akeyless >= 5.0.8",
 ]
 credentials-akeyless-ssh = [
+  "awx_plugins.interfaces",
+  "akeyless >= 5.0.8",
+]
+credentials-akeyless-oidc = [
+  "awx_plugins.interfaces",
+  "akeyless >= 5.0.8",
+]
+credentials-akeyless-ssh-oidc = [
   "awx_plugins.interfaces",
   "akeyless >= 5.0.8",
 ]

--- a/src/awx_plugins/credentials/akeyless.py
+++ b/src/awx_plugins/credentials/akeyless.py
@@ -28,8 +28,10 @@ from . import plugin as _plugin
 
 __all__ = (  # noqa: WPS410
     'akeyless_backend',
+    'akeyless_oidc_plugin',
     'akeyless_plugin',
     'akeyless_ssh_backend',
+    'akeyless_ssh_oidc_plugin',
     'akeyless_ssh_plugin',
 )
 
@@ -42,9 +44,14 @@ _PASSWORD_KEYS = frozenset(('username', 'password'))
 
 
 class _AkeylessCommonKwargs(_t.TypedDict):
-    gateway_url: str
     access_id: str
-    access_key: str
+    # `gateway_url` on the API key credential types, `url` on the OIDC ones.
+    gateway_url: _t.NotRequired[str]
+    url: _t.NotRequired[str]
+    # `access_key` is supplied by the user, `workload_identity_token` is
+    # injected by the controller for the OIDC credential types.
+    access_key: _t.NotRequired[str]
+    workload_identity_token: _t.NotRequired[str]
     ca_cert: _t.NotRequired[str | None]
 
 
@@ -101,38 +108,160 @@ class _AkeylessApi(_t.Protocol):
     ) -> _SshCertResponse: ...
 
 
+_gateway_url_field = {
+    'id': 'gateway_url',
+    'label': _('Gateway URL'),
+    'type': 'string',
+    'help_text': _(
+        'The URL of your Akeyless Gateway (e.g., https://api.akeyless.io, '
+        'https://my.akeyless.gw/api/v2)',
+    ),
+    'default': 'https://api.akeyless.io',
+}
+
+
+# The OIDC credential types must name this field `url`: the controller reads
+# the audience of the workload identity token it mints from the input with
+# that exact name.
+_url_field = {
+    'id': 'url',
+    'label': _('Gateway URL'),
+    'type': 'string',
+    'help_text': _(
+        'The URL of your Akeyless Gateway (e.g., https://api.akeyless.io, '
+        'https://my.akeyless.gw/api/v2). This value is also sent as the '
+        'audience of the workload identity token, so it must match the '
+        'audience configured on the Akeyless JWT auth method.',
+    ),
+    'default': 'https://api.akeyless.io',
+}
+
+
+_access_id_field = {
+    'id': 'access_id',
+    'label': _('Access ID'),
+    'type': 'string',
+    'help_text': _('Your Akeyless API Access ID'),
+}
+
+
+_oidc_access_id_field = {
+    'id': 'access_id',
+    'label': _('Access ID'),
+    'type': 'string',
+    'help_text': _(
+        'The Access ID of the Akeyless JWT auth method that trusts your '
+        'automation platform as an OIDC issuer (e.g., p-1a2b3c4d5e6f).',
+    ),
+}
+
+
+_access_key_field = {
+    'id': 'access_key',
+    'label': _('Access Key'),
+    'type': 'string',
+    'help_text': _('Your Akeyless API Access Key'),
+    'secret': True,
+}
+
+
+_ca_cert_field = {
+    'id': 'ca_cert',
+    'label': _('CA Certificate'),
+    'type': 'string',
+    'multiline': True,
+    'help_text': _(
+        'CA certificate (PEM format) used to verify the gateway TLS '
+        'certificate.',
+    ),
+}
+
+
+_workload_identity_token_field = {
+    'id': 'workload_identity_token',
+    'label': _('Workload Identity Token'),
+    'type': 'string',
+    'secret': True,
+    'internal': True,
+    'help_text': _(
+        'JWT token for workload identity authentication. '
+        'Automatically populated by the system.',
+    ),
+}
+
+
 _common_plugin_inputs = [
+    _gateway_url_field,
+    _access_id_field,
+    _access_key_field,
+    _ca_cert_field,
+]
+
+
+_common_oidc_plugin_inputs = [
+    _url_field,
+    _oidc_access_id_field,
+    _ca_cert_field,
+    _workload_identity_token_field,
+]
+
+
+_secret_metadata = [
     {
-        'id': 'gateway_url',
-        'label': _('Gateway URL'),
+        'id': 'secret_path',
+        'label': _('Secret Path'),
         'type': 'string',
         'help_text': _(
-            'The URL of your Akeyless Gateway (e.g., https://api.akeyless.io, '
-            'https://my.akeyless.gw/api/v2)',
+            'The path to the secret in Akeyless (e.g., '
+            '/myapp/database/password).',
         ),
-        'default': 'https://api.akeyless.io',
     },
     {
-        'id': 'access_id',
-        'label': _('Access ID'),
+        'id': 'secret_key',
+        'label': _('Secret Key'),
         'type': 'string',
-        'help_text': _('Your Akeyless API Access ID'),
-    },
-    {
-        'id': 'access_key',
-        'label': _('Access Key'),
-        'type': 'string',
-        'help_text': _('Your Akeyless API Access Key'),
-        'secret': True,
-    },
-    {
-        'id': 'ca_cert',
-        'label': _('CA Certificate'),
-        'type': 'string',
-        'multiline': True,
         'help_text': _(
-            'CA certificate (PEM format) used to verify the gateway TLS '
-            'certificate.',
+            'Optional key within the secret to retrieve (for JSON or '
+            'key-value secrets).',
+        ),
+    },
+]
+
+
+_ssh_metadata = [
+    {
+        'id': 'cert_issue_name',
+        'label': _('Certificate Issuer Name'),
+        'type': 'string',
+        'help_text': _(
+            'The full path to the certificate issuer in Akeyless (e.g., '
+            '/remote/ssh/certificate/issuer).',
+        ),
+    },
+    {
+        'id': 'cert_username',
+        'label': _('Certificate Username'),
+        'type': 'string',
+        'help_text': _(
+            'The username(s) to sign into the SSH certificate in a '
+            'comma-separated list, e.g., "ubuntu,nobody,nonroot".',
+        ),
+    },
+    {
+        'id': 'public_key_data',
+        'label': _('Public Key Data'),
+        'type': 'string',
+        'help_text': _(
+            'The public key data to sign (e.g. "ssh-rsa AAAAB3NzaC1yc2E...").',
+        ),
+    },
+    {
+        'id': 'ttl',
+        'label': _('TTL'),
+        'type': 'number',
+        'help_text': _(
+            'Time to live in seconds for the SSH certificate. If not '
+            'defined, the default issuer TTL is used.',
         ),
     },
 ]
@@ -140,26 +269,7 @@ _common_plugin_inputs = [
 
 _akeyless_inputs = {
     'fields': _common_plugin_inputs,
-    'metadata': [
-        {
-            'id': 'secret_path',
-            'label': _('Secret Path'),
-            'type': 'string',
-            'help_text': _(
-                'The path to the secret in Akeyless (e.g., '
-                '/myapp/database/password).',
-            ),
-        },
-        {
-            'id': 'secret_key',
-            'label': _('Secret Key'),
-            'type': 'string',
-            'help_text': _(
-                'Optional key within the secret to retrieve (for JSON or '
-                'key-value secrets).',
-            ),
-        },
-    ],
+    'metadata': _secret_metadata,
     'required': [
         'gateway_url',
         'access_id',
@@ -169,49 +279,37 @@ _akeyless_inputs = {
 }
 
 
+_akeyless_oidc_inputs = {
+    'fields': _common_oidc_plugin_inputs,
+    'metadata': _secret_metadata,
+    'required': [
+        'url',
+        'access_id',
+        'secret_path',
+    ],
+}
+
+
 _akeyless_ssh_inputs = {
     'fields': _common_plugin_inputs,
-    'metadata': [
-        {
-            'id': 'cert_issue_name',
-            'label': _('Certificate Issuer Name'),
-            'type': 'string',
-            'help_text': _(
-                'The full path to the certificate issuer in Akeyless (e.g., '
-                '/remote/ssh/certificate/issuer).',
-            ),
-        },
-        {
-            'id': 'cert_username',
-            'label': _('Certificate Username'),
-            'type': 'string',
-            'help_text': _(
-                'The username(s) to sign into the SSH certificate in a '
-                'comma-separated list, e.g., "ubuntu,nobody,nonroot".',
-            ),
-        },
-        {
-            'id': 'public_key_data',
-            'label': _('Public Key Data'),
-            'type': 'string',
-            'help_text': _(
-                'The public key data to sign (e.g. "ssh-rsa AAAAB3NzaC1yc2E...").',
-            ),
-        },
-        {
-            'id': 'ttl',
-            'label': _('TTL'),
-            'type': 'number',
-            'help_text': _(
-                'Time to live in seconds for the SSH certificate. If not '
-                'defined, the default issuer TTL is used.',
-            ),
-        },
-    ],
+    'metadata': _ssh_metadata,
     'required': [
         'gateway_url',
         'access_id',
         'access_key',
+        'cert_issue_name',
+        'cert_username',
+        'public_key_data',
+    ],
+}
+
+
+_akeyless_ssh_oidc_inputs = {
+    'fields': _common_oidc_plugin_inputs,
+    'metadata': _ssh_metadata,
+    'required': [
+        'url',
+        'access_id',
         'cert_issue_name',
         'cert_username',
         'public_key_data',
@@ -230,17 +328,39 @@ def _setup_client(gateway_url: str, ca_cert_path: str | None) -> _AkeylessApi:
     return _V2Api(api_client)  # type: ignore[return-value]
 
 
-def _authenticate(
-    api_instance: _AkeylessApi,
-    access_id: str,
-    access_key: str,
-) -> str:
-    auth_response = api_instance.auth(
-        _Auth(
+def _resolve_gateway_url(kwargs: _AkeylessCommonKwargs) -> str:
+    gateway_url = kwargs.get('url') or kwargs.get('gateway_url')
+    if not gateway_url:
+        raise ValueError('An Akeyless Gateway URL must be set.')
+    return gateway_url.rstrip('/')
+
+
+def _build_auth_request(kwargs: _AkeylessCommonKwargs) -> _Auth:
+    access_id = kwargs['access_id']
+    workload_identity_token = kwargs.get('workload_identity_token')
+    if workload_identity_token:
+        return _Auth(
+            access_type='jwt',
+            access_id=access_id,
+            jwt=workload_identity_token,
+        )
+    access_key = kwargs.get('access_key')
+    if access_key:
+        return _Auth(
             access_id=access_id,
             access_key=access_key,
-        ),
+        )
+    raise ValueError(
+        'Either an Access Key or a workload identity token is required '
+        'to authenticate with Akeyless.',
     )
+
+
+def _authenticate(
+    api_instance: _AkeylessApi,
+    kwargs: _AkeylessCommonKwargs,
+) -> str:
+    auth_response = api_instance.auth(_build_auth_request(kwargs))
     if not auth_response.token:
         raise ValueError(
             'Failed to authenticate with Akeyless: no token received.',
@@ -357,15 +477,11 @@ def akeyless_backend(**kwargs: _t.Unpack[_AkeylessBackendKwargs]) -> str:
     """Retrieve a secret value from Akeyless."""
     with _plugin.CertFiles(kwargs.get('ca_cert')) as ca_cert_path:
         api_instance = _setup_client(
-            kwargs['gateway_url'].rstrip('/'),
+            _resolve_gateway_url(kwargs),
             ca_cert_path,
         )
         try:
-            token = _authenticate(
-                api_instance,
-                kwargs['access_id'],
-                kwargs['access_key'],
-            )
+            token = _authenticate(api_instance, kwargs)
         except _ApiException as api_exc:
             raise RuntimeError(
                 f'Akeyless API error: {api_exc.reason}'
@@ -423,15 +539,11 @@ def akeyless_ssh_backend(
     """Generate a signed SSH certificate using Akeyless."""
     with _plugin.CertFiles(kwargs.get('ca_cert')) as ca_cert_path:
         api_instance = _setup_client(
-            kwargs['gateway_url'].rstrip('/'),
+            _resolve_gateway_url(kwargs),
             ca_cert_path,
         )
         try:
-            token = _authenticate(
-                api_instance,
-                kwargs['access_id'],
-                kwargs['access_key'],
-            )
+            token = _authenticate(api_instance, kwargs)
         except _ApiException as api_exc:
             raise RuntimeError(
                 f'Akeyless API error: {api_exc.reason}'
@@ -454,6 +566,12 @@ def akeyless_ssh_backend(
             raise RuntimeError(str(val_err)) from val_err
 
 
+_OIDC_PLUGIN_DESCRIPTION = (
+    'Uses OIDC/JWT authentication for enhanced security with short-lived '
+    'tokens'
+)
+
+
 akeyless_plugin = _plugin.CredentialPlugin(
     'Akeyless',
     inputs=_akeyless_inputs,  # type: ignore[arg-type]
@@ -465,4 +583,20 @@ akeyless_ssh_plugin = _plugin.CredentialPlugin(
     'Akeyless SSH',
     inputs=_akeyless_ssh_inputs,  # type: ignore[arg-type]
     backend=akeyless_ssh_backend,
+)
+
+
+akeyless_oidc_plugin = _plugin.CredentialPlugin(
+    'Akeyless (OIDC)',
+    inputs=_akeyless_oidc_inputs,  # type: ignore[arg-type]
+    backend=akeyless_backend,
+    plugin_description=_OIDC_PLUGIN_DESCRIPTION,
+)
+
+
+akeyless_ssh_oidc_plugin = _plugin.CredentialPlugin(
+    'Akeyless SSH (OIDC)',
+    inputs=_akeyless_ssh_oidc_inputs,  # type: ignore[arg-type]
+    backend=akeyless_ssh_backend,
+    plugin_description=_OIDC_PLUGIN_DESCRIPTION,
 )

--- a/src/awx_plugins/credentials/akeyless.py
+++ b/src/awx_plugins/credentials/akeyless.py
@@ -1,8 +1,12 @@
 """Akeyless credential plugins for AWX."""
 
+import contextlib as _contextlib
 import json as _json
 import typing as _t
-from collections.abc import Mapping as _Mapping
+from collections.abc import (
+    Iterator as _Iterator,
+    Mapping as _Mapping,
+)
 
 from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
     gettext_noop as _,
@@ -368,6 +372,13 @@ def _authenticate(
     return auth_response.token
 
 
+def _load_secret_json(secret_data: str) -> dict[str, str]:
+    try:
+        return _t.cast('dict[str, str]', _json.loads(secret_data))
+    except _json.JSONDecodeError as exc:
+        raise ValueError('Secret data not valid JSON') from exc
+
+
 def _extract_password_secret(secret_data: str, secret_key: str | None) -> str:
     if not secret_key:
         return secret_data
@@ -375,13 +386,13 @@ def _extract_password_secret(secret_data: str, secret_key: str | None) -> str:
         raise NotImplementedError(
             'Password secrets only support "username" or "password" keys.',
         )
+    secret_dict = _load_secret_json(secret_data)
     try:
-        secret_dict = _t.cast('dict[str, str]', _json.loads(secret_data))
-    except _json.JSONDecodeError as exc:
+        return secret_dict[secret_key]
+    except KeyError as exc:
         raise ValueError(
-            'Secret data not valid JSON',
+            f'Key "{secret_key}" not found in the password secret.',
         ) from exc
-    return secret_dict[secret_key]
 
 
 def _extract_text_secret(
@@ -405,16 +416,11 @@ def _extract_structured_secret(
 ) -> str:
     if not secret_key:
         return str(secret_data)
-    try:
-        secret_dict = _t.cast('dict[str, str]', _json.loads(secret_data))
-    except _json.JSONDecodeError as exc:
-        raise ValueError(
-            'Secret data not valid JSON',
-        ) from exc
+    secret_dict = _load_secret_json(secret_data)
     try:
         return secret_dict[secret_key]
     except KeyError as exc:
-        raise KeyError(
+        raise ValueError(
             f'Key "{secret_key}" not found in secret at path: {secret_path}',
         ) from exc
 
@@ -426,7 +432,12 @@ def _extract_secret_value(
     static_secret_format: str,
     static_secret_sub_type: str,
 ) -> str:
-    secret_data = secret_response[secret_path]
+    try:
+        secret_data = secret_response[secret_path]
+    except KeyError as exc:
+        raise ValueError(
+            f'No secret data returned for path: {secret_path}',
+        ) from exc
     if static_secret_format == 'text':
         return _extract_text_secret(
             secret_data,
@@ -483,34 +494,36 @@ def _fetch_secret_value(
     )
 
 
+@_contextlib.contextmanager
+def _wrapped_api_errors() -> _Iterator[None]:
+    """Surface every Akeyless failure to the caller as ``RuntimeError``."""
+    try:
+        yield
+    except _ApiException as api_exc:
+        raise RuntimeError(
+            f'Akeyless API error: {api_exc.reason} (Status: {api_exc.status})',
+        ) from api_exc
+    except ValueError as val_err:
+        raise RuntimeError(str(val_err)) from val_err
+
+
 def akeyless_backend(**kwargs: _t.Unpack[_AkeylessBackendKwargs]) -> str:
     """Retrieve a secret value from Akeyless."""
-    with _plugin.CertFiles(kwargs.get('ca_cert')) as ca_cert_path:
+    with (
+        _wrapped_api_errors(),
+        _plugin.CertFiles(kwargs.get('ca_cert')) as ca_cert_path,
+    ):
         api_instance = _setup_client(
             _resolve_gateway_url(kwargs),
             ca_cert_path,
         )
-        try:
-            token = _authenticate(api_instance, kwargs)
-        except _ApiException as api_exc:
-            raise RuntimeError(
-                f'Akeyless API error: {api_exc.reason}'
-                f' (Status: {api_exc.status})',
-            ) from api_exc
-        except ValueError as val_err:
-            raise RuntimeError(str(val_err)) from val_err
-        try:
-            return _fetch_secret_value(
-                api_instance,
-                token,
-                kwargs['secret_path'],
-                kwargs.get('secret_key'),
-            )
-        except _ApiException as api_exc:
-            raise RuntimeError(
-                f'Akeyless API error: {api_exc.reason}'
-                f' (Status: {api_exc.status})',
-            ) from api_exc
+        token = _authenticate(api_instance, kwargs)
+        return _fetch_secret_value(
+            api_instance,
+            token,
+            kwargs['secret_path'],
+            kwargs.get('secret_key'),
+        )
 
 
 def _coerce_ttl(ttl_value: int | str | None) -> int | None:
@@ -547,33 +560,20 @@ def akeyless_ssh_backend(
     **kwargs: _t.Unpack[_AkeylessSshBackendKwargs],
 ) -> str:
     """Generate a signed SSH certificate using Akeyless."""
-    with _plugin.CertFiles(kwargs.get('ca_cert')) as ca_cert_path:
+    with (
+        _wrapped_api_errors(),
+        _plugin.CertFiles(kwargs.get('ca_cert')) as ca_cert_path,
+    ):
         api_instance = _setup_client(
             _resolve_gateway_url(kwargs),
             ca_cert_path,
         )
-        try:
-            token = _authenticate(api_instance, kwargs)
-        except _ApiException as api_exc:
-            raise RuntimeError(
-                f'Akeyless API error: {api_exc.reason}'
-                f' (Status: {api_exc.status})',
-            ) from api_exc
-        except ValueError as val_err:
-            raise RuntimeError(str(val_err)) from val_err
-        try:
-            return _fetch_ssh_certificate(
-                api_instance,
-                token,
-                kwargs,
-            )
-        except _ApiException as api_exc:
-            raise RuntimeError(
-                f'Akeyless API error: {api_exc.reason}'
-                f' (Status: {api_exc.status})',
-            ) from api_exc
-        except ValueError as val_err:
-            raise RuntimeError(str(val_err)) from val_err
+        token = _authenticate(api_instance, kwargs)
+        return _fetch_ssh_certificate(
+            api_instance,
+            token,
+            kwargs,
+        )
 
 
 _OIDC_PLUGIN_DESCRIPTION = (

--- a/src/awx_plugins/credentials/akeyless.py
+++ b/src/awx_plugins/credentials/akeyless.py
@@ -374,9 +374,12 @@ def _authenticate(
 
 def _load_secret_json(secret_data: str) -> dict[str, str]:
     try:
-        return _t.cast('dict[str, str]', _json.loads(secret_data))
+        loaded_secret = _json.loads(secret_data)
     except _json.JSONDecodeError as exc:
         raise ValueError('Secret data not valid JSON') from exc
+    if isinstance(loaded_secret, dict):
+        return _t.cast('dict[str, str]', loaded_secret)
+    raise ValueError('Secret data not a JSON object')
 
 
 def _extract_password_secret(secret_data: str, secret_key: str | None) -> str:

--- a/src/awx_plugins/credentials/akeyless.py
+++ b/src/awx_plugins/credentials/akeyless.py
@@ -1,0 +1,468 @@
+"""Akeyless credential plugins for AWX."""
+
+import json as _json
+import typing as _t
+from collections.abc import Mapping as _Mapping
+
+from awx_plugins.interfaces._temporary_private_django_api import (  # noqa: WPS436
+    gettext_noop as _,
+)
+
+# pylint: disable=import-error,import-self
+from akeyless import (
+    ApiClient as _ApiClient,
+    Auth as _Auth,
+    Configuration as _Configuration,
+    DescribeItem as _DescribeItem,
+    GetSecretValue as _GetSecretValue,
+    V2Api as _V2Api,
+)
+from akeyless.models.get_ssh_certificate import (
+    GetSSHCertificate as _GetSSHCertificate,
+)
+from akeyless.rest import ApiException as _ApiException
+
+# pylint: enable=import-error,import-self
+from . import plugin as _plugin
+
+
+__all__ = (  # noqa: WPS410
+    'akeyless_backend',
+    'akeyless_plugin',
+    'akeyless_ssh_backend',
+    'akeyless_ssh_plugin',
+)
+
+
+_SUPPORTED_ITEM_TYPES = frozenset(('STATIC_SECRET',))
+
+_STRUCTURED_SECRET_FORMATS = frozenset(('json', 'key-value'))
+
+_PASSWORD_KEYS = frozenset(('username', 'password'))
+
+
+class _AkeylessCommonKwargs(_t.TypedDict):
+    gateway_url: str
+    access_id: str
+    access_key: str
+    ca_cert: _t.NotRequired[str | None]
+
+
+class _AkeylessBackendKwargs(_AkeylessCommonKwargs):
+    secret_path: str
+    secret_key: _t.NotRequired[str | None]
+
+
+class _AkeylessSshBackendKwargs(_AkeylessCommonKwargs):
+    cert_issue_name: str
+    cert_username: str
+    public_key_data: str
+    ttl: _t.NotRequired[int | str | None]
+
+
+class _AuthResponse(_t.Protocol):
+    token: str | None
+
+
+class _StaticSecretInfo(_t.Protocol):
+    format: str
+
+
+class _ItemGeneralInfo(_t.Protocol):
+    static_secret_info: _StaticSecretInfo
+
+
+class _DescribeItemResponse(_t.Protocol):
+    item_type: str
+    item_sub_type: str
+    item_general_info: _ItemGeneralInfo
+
+
+class _SshCertResponse(_t.Protocol):
+    data: str | None  # noqa: WPS110  # must match the akeyless SDK response attribute name
+
+
+class _AkeylessApi(_t.Protocol):
+    def auth(self: _t.Self, auth: _Auth) -> _AuthResponse: ...
+
+    def describe_item(
+        self: _t.Self,
+        req: _DescribeItem,
+    ) -> _DescribeItemResponse: ...
+
+    def get_secret_value(
+        self: _t.Self,
+        req: _GetSecretValue,
+    ) -> _Mapping[str, str]: ...
+
+    def get_ssh_certificate(
+        self: _t.Self,
+        req: _GetSSHCertificate,
+    ) -> _SshCertResponse: ...
+
+
+_common_plugin_inputs = [
+    {
+        'id': 'gateway_url',
+        'label': _('Gateway URL'),
+        'type': 'string',
+        'help_text': _(
+            'The URL of your Akeyless Gateway (e.g., https://api.akeyless.io, '
+            'https://my.akeyless.gw/api/v2)',
+        ),
+        'default': 'https://api.akeyless.io',
+    },
+    {
+        'id': 'access_id',
+        'label': _('Access ID'),
+        'type': 'string',
+        'help_text': _('Your Akeyless API Access ID'),
+    },
+    {
+        'id': 'access_key',
+        'label': _('Access Key'),
+        'type': 'string',
+        'help_text': _('Your Akeyless API Access Key'),
+        'secret': True,
+    },
+    {
+        'id': 'ca_cert',
+        'label': _('CA Certificate'),
+        'type': 'string',
+        'multiline': True,
+        'help_text': _(
+            'CA certificate (PEM format) used to verify the gateway TLS '
+            'certificate.',
+        ),
+    },
+]
+
+
+_akeyless_inputs = {
+    'fields': _common_plugin_inputs,
+    'metadata': [
+        {
+            'id': 'secret_path',
+            'label': _('Secret Path'),
+            'type': 'string',
+            'help_text': _(
+                'The path to the secret in Akeyless (e.g., '
+                '/myapp/database/password).',
+            ),
+        },
+        {
+            'id': 'secret_key',
+            'label': _('Secret Key'),
+            'type': 'string',
+            'help_text': _(
+                'Optional key within the secret to retrieve (for JSON or '
+                'key-value secrets).',
+            ),
+        },
+    ],
+    'required': [
+        'gateway_url',
+        'access_id',
+        'access_key',
+        'secret_path',
+    ],
+}
+
+
+_akeyless_ssh_inputs = {
+    'fields': _common_plugin_inputs,
+    'metadata': [
+        {
+            'id': 'cert_issue_name',
+            'label': _('Certificate Issuer Name'),
+            'type': 'string',
+            'help_text': _(
+                'The full path to the certificate issuer in Akeyless (e.g., '
+                '/remote/ssh/certificate/issuer).',
+            ),
+        },
+        {
+            'id': 'cert_username',
+            'label': _('Certificate Username'),
+            'type': 'string',
+            'help_text': _(
+                'The username(s) to sign into the SSH certificate in a '
+                'comma-separated list, e.g., "ubuntu,nobody,nonroot".',
+            ),
+        },
+        {
+            'id': 'public_key_data',
+            'label': _('Public Key Data'),
+            'type': 'string',
+            'help_text': _(
+                'The public key data to sign (e.g. "ssh-rsa AAAAB3NzaC1yc2E...").',
+            ),
+        },
+        {
+            'id': 'ttl',
+            'label': _('TTL'),
+            'type': 'number',
+            'help_text': _(
+                'Time to live in seconds for the SSH certificate. If not '
+                'defined, the default issuer TTL is used.',
+            ),
+        },
+    ],
+    'required': [
+        'gateway_url',
+        'access_id',
+        'access_key',
+        'cert_issue_name',
+        'cert_username',
+        'public_key_data',
+    ],
+}
+
+
+def _setup_client(gateway_url: str, ca_cert_path: str | None) -> _AkeylessApi:
+    client_configuration = _Configuration(host=gateway_url)
+    if ca_cert_path:
+        client_configuration.ssl_ca_cert = ca_cert_path
+        client_configuration.verify_ssl = True
+    api_client = _ApiClient(client_configuration)
+    api_client.user_agent = 'AWX'
+    api_client.default_headers['akeylessclienttype'] = 'AWX'
+    return _V2Api(api_client)  # type: ignore[return-value]
+
+
+def _authenticate(
+    api_instance: _AkeylessApi,
+    access_id: str,
+    access_key: str,
+) -> str:
+    auth_response = api_instance.auth(
+        _Auth(
+            access_id=access_id,
+            access_key=access_key,
+        ),
+    )
+    if not auth_response.token:
+        raise ValueError(
+            'Failed to authenticate with Akeyless: no token received.',
+        )
+    return auth_response.token
+
+
+def _extract_password_secret(secret_data: str, secret_key: str | None) -> str:
+    if not secret_key:
+        return secret_data
+    if secret_key not in _PASSWORD_KEYS:
+        raise NotImplementedError(
+            'Password secrets only support "username" or "password" keys.',
+        )
+    secret_dict = _t.cast('dict[str, str]', _json.loads(secret_data))
+    return secret_dict[secret_key]
+
+
+def _extract_text_secret(
+    secret_data: str,
+    secret_key: str | None,
+    static_secret_sub_type: str,
+) -> str:
+    if static_secret_sub_type == 'password':
+        return _extract_password_secret(secret_data, secret_key)
+    if static_secret_sub_type == 'generic':
+        return secret_data
+    raise NotImplementedError(
+        'Static secret sub type must be "password" or "generic".',
+    )
+
+
+def _extract_structured_secret(
+    secret_data: str,
+    secret_key: str | None,
+    secret_path: str,
+) -> str:
+    if not secret_key:
+        return str(secret_data)
+    secret_dict = _t.cast('dict[str, str]', _json.loads(secret_data))
+    try:
+        return secret_dict[secret_key]
+    except KeyError as exc:
+        raise KeyError(
+            f'Key "{secret_key}" not found in secret at path: {secret_path}',
+        ) from exc
+
+
+def _extract_secret_value(
+    secret_response: _Mapping[str, str],
+    secret_path: str,
+    secret_key: str | None,
+    static_secret_format: str,
+    static_secret_sub_type: str,
+) -> str:
+    secret_data = secret_response[secret_path]
+    if static_secret_format == 'text':
+        return _extract_text_secret(
+            secret_data,
+            secret_key,
+            static_secret_sub_type,
+        )
+    if static_secret_format in _STRUCTURED_SECRET_FORMATS:
+        return _extract_structured_secret(
+            secret_data,
+            secret_key,
+            secret_path,
+        )
+    raise NotImplementedError(
+        'Static secret format must be "text", "json", or "key-value".',
+    )
+
+
+def _ensure_supported_item_type(secret_path: str, item_type: str) -> None:
+    if item_type not in _SUPPORTED_ITEM_TYPES:
+        raise NotImplementedError(
+            f'Secret "{secret_path}" is of type "{item_type}". '
+            f'Supported types: {sorted(_SUPPORTED_ITEM_TYPES)}.',
+        )
+
+
+def _fetch_secret_value(
+    api_instance: _AkeylessApi,
+    token: str,
+    secret_path: str,
+    secret_key: str | None,
+) -> str:
+    describe_item_request = _DescribeItem(name=secret_path, token=token)
+    describe_item_response = api_instance.describe_item(describe_item_request)
+    _ensure_supported_item_type(secret_path, describe_item_response.item_type)
+
+    static_secret_format = (
+        describe_item_response.item_general_info.static_secret_info.format
+    )
+    static_secret_sub_type = describe_item_response.item_sub_type
+
+    secret_response = api_instance.get_secret_value(
+        _GetSecretValue(
+            names=[secret_path],
+            token=token,
+        ),
+    )
+
+    return _extract_secret_value(
+        secret_response,
+        secret_path,
+        secret_key,
+        static_secret_format,
+        static_secret_sub_type,
+    )
+
+
+def akeyless_backend(**kwargs: _t.Unpack[_AkeylessBackendKwargs]) -> str:
+    """Retrieve a secret value from Akeyless."""
+    with _plugin.CertFiles(kwargs.get('ca_cert')) as ca_cert_path:
+        api_instance = _setup_client(
+            kwargs['gateway_url'].rstrip('/'),
+            ca_cert_path,
+        )
+        try:
+            token = _authenticate(
+                api_instance,
+                kwargs['access_id'],
+                kwargs['access_key'],
+            )
+        except _ApiException as api_exc:
+            raise RuntimeError(
+                f'Akeyless API error: {api_exc.reason}'
+                f' (Status: {api_exc.status})',
+            ) from api_exc
+        except ValueError as val_err:
+            raise RuntimeError(str(val_err)) from val_err
+        try:
+            return _fetch_secret_value(
+                api_instance,
+                token,
+                kwargs['secret_path'],
+                kwargs.get('secret_key'),
+            )
+        except _ApiException as api_exc:
+            raise RuntimeError(
+                f'Akeyless API error: {api_exc.reason}'
+                f' (Status: {api_exc.status})',
+            ) from api_exc
+
+
+def _coerce_ttl(ttl_value: int | str | None) -> int | None:
+    if ttl_value is None or ttl_value == '':
+        return None
+    try:
+        return int(ttl_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError('TTL must be an integer number of seconds.') from exc
+
+
+def _fetch_ssh_certificate(
+    api_instance: _AkeylessApi,
+    token: str,
+    ssh_inputs: _AkeylessSshBackendKwargs,
+) -> str:
+    response = api_instance.get_ssh_certificate(
+        _GetSSHCertificate(
+            token=token,
+            cert_issuer_name=ssh_inputs['cert_issue_name'],
+            cert_username=ssh_inputs['cert_username'],
+            ttl=_coerce_ttl(ssh_inputs.get('ttl')),
+            public_key_data=ssh_inputs['public_key_data'],
+        ),
+    )
+    if not response.data:
+        raise ValueError(
+            'Failed to generate signed SSH certificate: no data returned.',
+        )
+    return response.data
+
+
+def akeyless_ssh_backend(
+    **kwargs: _t.Unpack[_AkeylessSshBackendKwargs],
+) -> str:
+    """Generate a signed SSH certificate using Akeyless."""
+    with _plugin.CertFiles(kwargs.get('ca_cert')) as ca_cert_path:
+        api_instance = _setup_client(
+            kwargs['gateway_url'].rstrip('/'),
+            ca_cert_path,
+        )
+        try:
+            token = _authenticate(
+                api_instance,
+                kwargs['access_id'],
+                kwargs['access_key'],
+            )
+        except _ApiException as api_exc:
+            raise RuntimeError(
+                f'Akeyless API error: {api_exc.reason}'
+                f' (Status: {api_exc.status})',
+            ) from api_exc
+        except ValueError as val_err:
+            raise RuntimeError(str(val_err)) from val_err
+        try:
+            return _fetch_ssh_certificate(
+                api_instance,
+                token,
+                kwargs,
+            )
+        except _ApiException as api_exc:
+            raise RuntimeError(
+                f'Akeyless API error: {api_exc.reason}'
+                f' (Status: {api_exc.status})',
+            ) from api_exc
+        except ValueError as val_err:
+            raise RuntimeError(str(val_err)) from val_err
+
+
+akeyless_plugin = _plugin.CredentialPlugin(
+    'Akeyless',
+    inputs=_akeyless_inputs,  # type: ignore[arg-type]
+    backend=akeyless_backend,
+)
+
+
+akeyless_ssh_plugin = _plugin.CredentialPlugin(
+    'Akeyless SSH',
+    inputs=_akeyless_ssh_inputs,  # type: ignore[arg-type]
+    backend=akeyless_ssh_backend,
+)

--- a/src/awx_plugins/credentials/akeyless.py
+++ b/src/awx_plugins/credentials/akeyless.py
@@ -375,7 +375,12 @@ def _extract_password_secret(secret_data: str, secret_key: str | None) -> str:
         raise NotImplementedError(
             'Password secrets only support "username" or "password" keys.',
         )
-    secret_dict = _t.cast('dict[str, str]', _json.loads(secret_data))
+    try:
+        secret_dict = _t.cast('dict[str, str]', _json.loads(secret_data))
+    except _json.JSONDecodeError as exc:
+        raise ValueError(
+            'Secret data not valid JSON',
+        ) from exc
     return secret_dict[secret_key]
 
 
@@ -400,7 +405,12 @@ def _extract_structured_secret(
 ) -> str:
     if not secret_key:
         return str(secret_data)
-    secret_dict = _t.cast('dict[str, str]', _json.loads(secret_data))
+    try:
+        secret_dict = _t.cast('dict[str, str]', _json.loads(secret_data))
+    except _json.JSONDecodeError as exc:
+        raise ValueError(
+            'Secret data not valid JSON',
+        ) from exc
     try:
         return secret_dict[secret_key]
     except KeyError as exc:

--- a/tests/akeyless_test.py
+++ b/tests/akeyless_test.py
@@ -16,6 +16,7 @@ _SECRET_PATH = '/test/secret'
 _ACCESS_ID = 'p-test123'
 _ACCESS_KEY = 'test-key'
 _GATEWAY_URL = 'https://api.akeyless.io'
+_WORKLOAD_JWT = 'eyJhbGciOiJSUzI1NiJ9.e30.c2ln'  # noqa: S105
 
 _HTTP_UNAUTHORIZED = 401
 _HTTP_FORBIDDEN = 403
@@ -139,6 +140,28 @@ def _ssh_kwargs(
     if ca_cert is not None:
         kwargs['ca_cert'] = ca_cert
     return kwargs
+
+
+def _oidc_backend_kwargs() -> dict[str, object]:
+    """Build kwargs as the controller sends them for the OIDC secret type."""
+    return {
+        'url': _GATEWAY_URL,
+        'access_id': _ACCESS_ID,
+        'workload_identity_token': _WORKLOAD_JWT,
+        'secret_path': _SECRET_PATH,
+    }
+
+
+def _oidc_ssh_kwargs() -> dict[str, object]:
+    """Build kwargs as the controller sends them for the OIDC SSH type."""
+    return {
+        'url': _GATEWAY_URL,
+        'access_id': _ACCESS_ID,
+        'workload_identity_token': _WORKLOAD_JWT,
+        'cert_issue_name': '/ssh/issuers/my-issuer',
+        'cert_username': 'ubuntu',
+        'public_key_data': 'ssh-rsa AAAAB3NzaC1yc2E...',
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -350,3 +373,108 @@ def test_coerce_ttl_invalid_raises() -> None:
         # WPS437: _coerce_ttl is private but is tested directly here intentionally
         # pylint: disable-next=protected-access
         akeyless_mod._coerce_ttl('not-a-number')  # noqa: WPS437
+
+
+# ---------------------------------------------------------------------------
+# OIDC / workload identity authentication
+# ---------------------------------------------------------------------------
+
+
+def test_oidc_backend_authenticates_with_jwt(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """A workload identity token should be exchanged via JWT auth."""
+    mock_api = patch_setup_client(secret_data='oidc-secret')
+
+    secret_value = akeyless_mod.akeyless_backend(**_oidc_backend_kwargs())
+
+    assert secret_value == 'oidc-secret'
+    auth_request = mock_api.auth.call_args.args[0]
+    assert auth_request.access_type == 'jwt'
+    assert auth_request.jwt == _WORKLOAD_JWT
+    assert auth_request.access_id == _ACCESS_ID
+    assert auth_request.access_key is None
+
+
+def test_oidc_ssh_backend_authenticates_with_jwt(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """SSH certificate issuance should also support workload identity."""
+    mock_api = patch_setup_client(ssh_cert_data='oidc-signed-cert')
+
+    signed_cert = akeyless_mod.akeyless_ssh_backend(**_oidc_ssh_kwargs())
+
+    assert signed_cert == 'oidc-signed-cert'
+    auth_request = mock_api.auth.call_args.args[0]
+    assert auth_request.access_type == 'jwt'
+    assert auth_request.jwt == _WORKLOAD_JWT
+
+
+def test_workload_identity_token_takes_precedence(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """A workload identity token should win over a stale access key."""
+    mock_api = patch_setup_client()
+
+    akeyless_mod.akeyless_backend(
+        **_oidc_backend_kwargs(),
+        access_key=_ACCESS_KEY,
+    )
+
+    auth_request = mock_api.auth.call_args.args[0]
+    assert auth_request.access_type == 'jwt'
+
+
+def test_missing_auth_material_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Neither an access key nor a token should be a clear failure."""
+    patch_setup_client()
+    kwargs = _oidc_backend_kwargs()
+    del kwargs['workload_identity_token']  # noqa: WPS420
+
+    with pytest.raises(
+        RuntimeError,
+        match='Access Key or a workload identity',
+    ):
+        akeyless_mod.akeyless_backend(**kwargs)
+
+
+def test_missing_gateway_url_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Neither `url` nor `gateway_url` should be a clear failure."""
+    patch_setup_client()
+    kwargs = _oidc_backend_kwargs()
+    del kwargs['url']  # noqa: WPS420
+
+    with pytest.raises(ValueError, match='Gateway URL must be set'):
+        akeyless_mod.akeyless_backend(**kwargs)
+
+
+@pytest.mark.parametrize(
+    'plugin',
+    (
+        pytest.param(akeyless_mod.akeyless_oidc_plugin, id='secret'),
+        pytest.param(akeyless_mod.akeyless_ssh_oidc_plugin, id='ssh'),
+    ),
+)
+def test_oidc_plugins_workload_contract(
+    plugin: object,
+) -> None:
+    """The OIDC types must match what the controller looks for.
+
+    It only injects a token into credential types exposing an internal
+    ``workload_identity_token`` field, and it reads the audience of that
+    token from the input named ``url``.
+    """
+    fields = plugin.inputs['fields']
+    token_fields = [
+        field for field in fields if field['id'] == 'workload_identity_token'
+    ]
+
+    assert [field['id'] for field in fields].count('url') == 1
+    assert len(token_fields) == 1
+    assert token_fields[0]['internal'] is True
+    assert token_fields[0]['secret'] is True
+    assert 'access_key' not in {field['id'] for field in fields}

--- a/tests/akeyless_test.py
+++ b/tests/akeyless_test.py
@@ -227,7 +227,7 @@ def test_backend_pwd_secret_invalid_json_raises(
         secret_data=payload,
     )
 
-    with pytest.raises(ValueError, match='Secret data not valid JSON'):
+    with pytest.raises(RuntimeError, match='Secret data not valid JSON'):
         akeyless_mod.akeyless_backend(**_backend_kwargs(secret_key='username'))
 
 
@@ -288,13 +288,13 @@ def test_backend_auth_api_exc_raises(
 def test_backend_missing_json_key_raises(
     patch_setup_client: _MockApiFactory,
 ) -> None:
-    """A missing key in a structured secret should raise KeyError with the path."""
+    """A missing key in a structured secret should name the secret path."""
     patch_setup_client(
         secret_format='json',
         secret_data='{"other_key": "value"}',
     )
 
-    with pytest.raises(KeyError, match=_SECRET_PATH):
+    with pytest.raises(RuntimeError, match=_SECRET_PATH):
         akeyless_mod.akeyless_backend(
             **_backend_kwargs(secret_key='missing_key'),
         )
@@ -463,7 +463,7 @@ def test_missing_gateway_url_raises(
     kwargs = _oidc_backend_kwargs()
     del kwargs['url']  # noqa: WPS420
 
-    with pytest.raises(ValueError, match='Gateway URL must be set'):
+    with pytest.raises(RuntimeError, match='Gateway URL must be set'):
         akeyless_mod.akeyless_backend(**kwargs)
 
 

--- a/tests/akeyless_test.py
+++ b/tests/akeyless_test.py
@@ -400,6 +400,28 @@ def test_backend_structured_invalid_json_raises(
         )
 
 
+@pytest.mark.parametrize(
+    'secret_data',
+    (
+        pytest.param('null', id='null'),
+        pytest.param('["s3cr3t"]', id='array'),
+        pytest.param('42', id='number'),
+        pytest.param('"s3cr3t"', id='string'),
+    ),
+)
+def test_backend_non_object_json_raises(
+    secret_data: str,
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Keyed lookups need a JSON object, not an array or a scalar."""
+    patch_setup_client(secret_format='json', secret_data=secret_data)
+
+    with pytest.raises(RuntimeError, match='Secret data not a JSON object'):
+        akeyless_mod.akeyless_backend(
+            **_backend_kwargs(secret_key='db_password'),
+        )
+
+
 def test_backend_path_missing_in_response(
     patch_setup_client: _MockApiFactory,
 ) -> None:

--- a/tests/akeyless_test.py
+++ b/tests/akeyless_test.py
@@ -216,6 +216,21 @@ def test_backend_password_secret_username_key(
     assert fetched_secret == 'myuser'
 
 
+def test_backend_pwd_secret_invalid_json_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Invalid json returned for password-type secret."""
+    payload = '"username": "invalid", "password": "json"}'
+    patch_setup_client(
+        item_sub_type='password',
+        secret_format='text',
+        secret_data=payload,
+    )
+
+    with pytest.raises(ValueError, match='Secret data not valid JSON'):
+        akeyless_mod.akeyless_backend(**_backend_kwargs(secret_key='username'))
+
+
 def test_backend_unsupported_type_raises(
     patch_setup_client: _MockApiFactory,
 ) -> None:

--- a/tests/akeyless_test.py
+++ b/tests/akeyless_test.py
@@ -1,0 +1,352 @@
+"""Tests for Akeyless credential plugins."""
+# mypy: disable-error-code="arg-type,explicit-any"
+
+import dataclasses
+from collections.abc import Callable
+
+import pytest
+from pytest_mock import MockerFixture
+
+from akeyless.rest import ApiException  # pylint: disable=import-error
+
+from awx_plugins.credentials import akeyless as akeyless_mod
+
+
+_SECRET_PATH = '/test/secret'
+_ACCESS_ID = 'p-test123'
+_ACCESS_KEY = 'test-key'
+_GATEWAY_URL = 'https://api.akeyless.io'
+
+_HTTP_UNAUTHORIZED = 401
+_HTTP_FORBIDDEN = 403
+_HTTP_NOT_FOUND = 404
+_ONE_HOUR_SEC = 3600
+_TWO_HOURS_SEC = 7200
+
+_MockApiFactory = Callable[..., object]
+
+
+@dataclasses.dataclass
+class _FakeStaticSecretInfo:
+    format: str = 'text'  # noqa: WPS125
+
+
+@dataclasses.dataclass
+class _FakeItemGeneralInfo:
+    static_secret_info: _FakeStaticSecretInfo = dataclasses.field(
+        default_factory=_FakeStaticSecretInfo,
+    )
+
+
+@dataclasses.dataclass
+class _FakeDescribeItemResponse:
+    item_type: str = 'STATIC_SECRET'
+    item_sub_type: str = 'generic'
+    item_general_info: _FakeItemGeneralInfo = dataclasses.field(
+        default_factory=_FakeItemGeneralInfo,
+    )
+
+
+@dataclasses.dataclass
+class _FakeAuthResponse:
+    token: str | None = 'test-token'
+
+
+@dataclasses.dataclass
+class _FakeSshCertResponse:
+    data: str | None = 'ssh-rsa-SIGNED-CERT'  # noqa: WPS110
+
+
+def _make_mock_api(  # noqa: WPS211  # pylint: disable=too-many-arguments
+    mocker: MockerFixture,
+    *,
+    token: str | None = 'test-token',
+    item_type: str = 'STATIC_SECRET',
+    item_sub_type: str = 'generic',
+    secret_format: str = 'text',
+    secret_path: str = _SECRET_PATH,
+    secret_data: str = 'my-secret-value',
+    ssh_cert_data: str | None = 'ssh-rsa-SIGNED-CERT',
+) -> object:
+    """Create a mock Akeyless API instance with configurable responses."""
+    mock_api = mocker.Mock()
+    mock_api.auth.return_value = _FakeAuthResponse(token=token)
+    mock_api.describe_item.return_value = _FakeDescribeItemResponse(
+        item_type=item_type,
+        item_sub_type=item_sub_type,
+        item_general_info=_FakeItemGeneralInfo(
+            static_secret_info=_FakeStaticSecretInfo(format=secret_format),
+        ),
+    )
+    mock_api.get_secret_value.return_value = {secret_path: secret_data}
+    mock_api.get_ssh_certificate.return_value = _FakeSshCertResponse(
+        data=ssh_cert_data,
+    )
+    return mock_api
+
+
+@pytest.fixture
+def patch_setup_client(
+    monkeypatch: pytest.MonkeyPatch,
+    mocker: MockerFixture,
+) -> _MockApiFactory:
+    """Patch _setup_client, returning a factory that yields the configured mock."""
+
+    def _factory(**kwargs: object) -> object:
+        mock = _make_mock_api(mocker, **kwargs)
+        monkeypatch.setattr(akeyless_mod, '_setup_client', lambda *_: mock)
+        return mock
+
+    return _factory
+
+
+def _backend_kwargs(
+    *,
+    secret_path: str = _SECRET_PATH,
+    secret_key: str | None = None,
+    ca_cert: str | None = None,
+) -> dict[str, object]:
+    """Build a minimal set of kwargs for akeyless_backend."""
+    kwargs: dict[str, object] = {
+        'gateway_url': _GATEWAY_URL,
+        'access_id': _ACCESS_ID,
+        'access_key': _ACCESS_KEY,
+        'secret_path': secret_path,
+    }
+    if secret_key is not None:
+        kwargs['secret_key'] = secret_key
+    if ca_cert is not None:
+        kwargs['ca_cert'] = ca_cert
+    return kwargs
+
+
+def _ssh_kwargs(
+    *,
+    ttl: int | str | None = None,
+    ca_cert: str | None = None,
+) -> dict[str, object]:
+    """Build a minimal set of kwargs for akeyless_ssh_backend."""
+    kwargs: dict[str, object] = {
+        'gateway_url': _GATEWAY_URL,
+        'access_id': _ACCESS_ID,
+        'access_key': _ACCESS_KEY,
+        'cert_issue_name': '/ssh/issuers/my-issuer',
+        'cert_username': 'ubuntu',
+        'public_key_data': 'ssh-rsa AAAAB3NzaC1yc2E...',
+    }
+    if ttl is not None:
+        kwargs['ttl'] = ttl
+    if ca_cert is not None:
+        kwargs['ca_cert'] = ca_cert
+    return kwargs
+
+
+# ---------------------------------------------------------------------------
+# akeyless_backend - secret store plugin
+# ---------------------------------------------------------------------------
+
+
+def test_akeyless_backend_text_generic_secret(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Retrieve a plain-text generic secret successfully."""
+    patch_setup_client(item_sub_type='generic', secret_format='text')
+
+    fetched_secret = akeyless_mod.akeyless_backend(
+        **_backend_kwargs(),
+    )
+
+    assert fetched_secret == 'my-secret-value'
+
+
+def test_akeyless_backend_json_secret_with_key(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Retrieve a specific key from a JSON-format structured secret."""
+    patch_setup_client(
+        secret_format='json',
+        secret_data='{"db_password": "s3cr3t", "db_user": "admin"}',
+    )
+
+    fetched_secret = akeyless_mod.akeyless_backend(
+        **_backend_kwargs(secret_key='db_password'),
+    )
+
+    assert fetched_secret == 's3cr3t'
+
+
+def test_backend_password_secret_username_key(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Retrieve the 'username' field from a text/password sub-type secret."""
+    payload = '{"username": "myuser", "password": "mypass"}'
+    patch_setup_client(
+        item_sub_type='password',
+        secret_format='text',
+        secret_data=payload,
+    )
+
+    fetched_secret = akeyless_mod.akeyless_backend(
+        **_backend_kwargs(secret_key='username'),
+    )
+
+    assert fetched_secret == 'myuser'
+
+
+def test_backend_unsupported_type_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Unsupported secret types (e.g. dynamic) should raise NotImplementedError."""
+    patch_setup_client(item_type='DYNAMIC_SECRET')
+
+    with pytest.raises(NotImplementedError, match='DYNAMIC_SECRET'):
+        akeyless_mod.akeyless_backend(**_backend_kwargs())
+
+
+def test_backend_api_exc_wraps_runtime(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """An ApiException from get_secret_value surfaces as RuntimeError."""
+    mock_api = patch_setup_client()
+    mock_api.get_secret_value.side_effect = ApiException(
+        status=_HTTP_FORBIDDEN,
+        reason='Forbidden',
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r'Akeyless API error: Forbidden \(Status: 403\)',
+    ):
+        akeyless_mod.akeyless_backend(**_backend_kwargs())
+
+
+def test_backend_auth_failure_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """A missing auth token should surface as RuntimeError to the plugin caller."""
+    patch_setup_client(token=None)
+
+    with pytest.raises(RuntimeError, match='no token received'):
+        akeyless_mod.akeyless_backend(**_backend_kwargs())
+
+
+def test_backend_auth_api_exc_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """An ApiException from auth should surface as RuntimeError."""
+    mock_api = patch_setup_client()
+    mock_api.auth.side_effect = ApiException(
+        status=_HTTP_UNAUTHORIZED,
+        reason='Unauthorized',
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r'Akeyless API error: Unauthorized \(Status: 401\)',
+    ):
+        akeyless_mod.akeyless_backend(**_backend_kwargs())
+
+
+def test_backend_missing_json_key_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """A missing key in a structured secret should raise KeyError with the path."""
+    patch_setup_client(
+        secret_format='json',
+        secret_data='{"other_key": "value"}',
+    )
+
+    with pytest.raises(KeyError, match=_SECRET_PATH):
+        akeyless_mod.akeyless_backend(
+            **_backend_kwargs(secret_key='missing_key'),
+        )
+
+
+# ---------------------------------------------------------------------------
+# akeyless_ssh_backend - SSH certificate plugin
+# ---------------------------------------------------------------------------
+
+
+def test_akeyless_ssh_backend_success(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Successfully generate a signed SSH certificate."""
+    patch_setup_client(ssh_cert_data='ssh-rsa-cert-AAAAAA')
+
+    signed_cert = akeyless_mod.akeyless_ssh_backend(**_ssh_kwargs())
+
+    assert signed_cert == 'ssh-rsa-cert-AAAAAA'
+
+
+def test_akeyless_ssh_backend_with_ttl(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """SSH certificate request with an explicit TTL should succeed."""
+    mock_api = patch_setup_client(ssh_cert_data='signed-cert')
+
+    signed_cert = akeyless_mod.akeyless_ssh_backend(
+        **_ssh_kwargs(ttl=_ONE_HOUR_SEC),
+    )
+
+    assert signed_cert == 'signed-cert'
+    ssh_request = mock_api.get_ssh_certificate.call_args.args[0]
+    assert ssh_request.ttl == _ONE_HOUR_SEC
+
+
+def test_ssh_backend_no_cert_data_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """An empty/None cert response should surface as RuntimeError."""
+    patch_setup_client(ssh_cert_data=None)
+
+    with pytest.raises(RuntimeError, match='no data returned'):
+        akeyless_mod.akeyless_ssh_backend(**_ssh_kwargs())
+
+
+def test_ssh_api_exc_wraps_runtime(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """An ApiException from get_ssh_certificate surfaces as RuntimeError."""
+    mock_api = patch_setup_client()
+    mock_api.get_ssh_certificate.side_effect = ApiException(
+        status=_HTTP_NOT_FOUND,
+        reason='Issuer not found',
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=r'Akeyless API error: Issuer not found \(Status: 404\)',
+    ):
+        akeyless_mod.akeyless_ssh_backend(**_ssh_kwargs())
+
+
+# ---------------------------------------------------------------------------
+# _coerce_ttl helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('ttl_input', 'expected'),
+    (
+        pytest.param(None, None, id='none'),
+        pytest.param('', None, id='empty-string'),
+        pytest.param(_ONE_HOUR_SEC, _ONE_HOUR_SEC, id='int'),
+        pytest.param('7200', _TWO_HOURS_SEC, id='string-int'),
+    ),
+)
+def test_coerce_ttl_valid_inputs(
+    ttl_input: int | str | None,
+    expected: int | None,
+) -> None:
+    """_coerce_ttl should convert numeric-like values and pass None/'' through."""
+    # WPS437: _coerce_ttl is private but is tested directly here intentionally
+    # pylint: disable-next=protected-access
+    assert akeyless_mod._coerce_ttl(ttl_input) == expected  # noqa: WPS437
+
+
+def test_coerce_ttl_invalid_raises() -> None:
+    """_coerce_ttl should raise ValueError for non-numeric strings."""
+    with pytest.raises(ValueError, match='integer number of seconds'):
+        # WPS437: _coerce_ttl is private but is tested directly here intentionally
+        # pylint: disable-next=protected-access
+        akeyless_mod._coerce_ttl('not-a-number')  # noqa: WPS437

--- a/tests/akeyless_test.py
+++ b/tests/akeyless_test.py
@@ -2,6 +2,7 @@
 # mypy: disable-error-code="arg-type,explicit-any"
 
 import dataclasses
+import pathlib
 from collections.abc import Callable
 
 import pytest
@@ -17,6 +18,11 @@ _ACCESS_ID = 'p-test123'
 _ACCESS_KEY = 'test-key'
 _GATEWAY_URL = 'https://api.akeyless.io'
 _WORKLOAD_JWT = 'eyJhbGciOiJSUzI1NiJ9.e30.c2ln'  # noqa: S105
+_CA_CERT_PEM = (
+    '-----BEGIN CERTIFICATE-----\n'
+    'ZmFrZS1jZXJ0aWZpY2F0ZQ==\n'
+    '-----END CERTIFICATE-----\n'
+)
 
 _HTTP_UNAUTHORIZED = 401
 _HTTP_FORBIDDEN = 403
@@ -198,10 +204,61 @@ def test_akeyless_backend_json_secret_with_key(
     assert fetched_secret == 's3cr3t'
 
 
-def test_backend_password_secret_username_key(
+def test_backend_key_value_secret_with_key(
     patch_setup_client: _MockApiFactory,
 ) -> None:
-    """Retrieve the 'username' field from a text/password sub-type secret."""
+    """Retrieve a specific key from a key-value format secret."""
+    patch_setup_client(
+        secret_format='key-value',
+        secret_data='{"api_key": "kv-value", "region": "us-east-1"}',
+    )
+
+    fetched_secret = akeyless_mod.akeyless_backend(
+        **_backend_kwargs(secret_key='api_key'),
+    )
+
+    assert fetched_secret == 'kv-value'
+
+
+@pytest.mark.parametrize(
+    ('item_sub_type', 'secret_format'),
+    (
+        pytest.param('password', 'text', id='password'),
+        pytest.param('generic', 'json', id='json'),
+        pytest.param('generic', 'key-value', id='key-value'),
+    ),
+)
+def test_backend_secret_without_key(
+    item_sub_type: str,
+    secret_format: str,
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Without a secret key, the whole payload is returned verbatim."""
+    payload = '{"username": "myuser", "password": "mypass"}'
+    patch_setup_client(
+        item_sub_type=item_sub_type,
+        secret_format=secret_format,
+        secret_data=payload,
+    )
+
+    fetched_secret = akeyless_mod.akeyless_backend(**_backend_kwargs())
+
+    assert fetched_secret == payload
+
+
+@pytest.mark.parametrize(
+    ('secret_key', 'expected'),
+    (
+        pytest.param('username', 'myuser', id='username'),
+        pytest.param('password', 'mypass', id='password'),
+    ),
+)
+def test_backend_password_secret_keys(
+    secret_key: str,
+    expected: str,
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Retrieve either field of a text/password sub-type secret."""
     payload = '{"username": "myuser", "password": "mypass"}'
     patch_setup_client(
         item_sub_type='password',
@@ -210,10 +267,38 @@ def test_backend_password_secret_username_key(
     )
 
     fetched_secret = akeyless_mod.akeyless_backend(
-        **_backend_kwargs(secret_key='username'),
+        **_backend_kwargs(secret_key=secret_key),
     )
 
-    assert fetched_secret == 'myuser'
+    assert fetched_secret == expected
+
+
+def test_backend_pwd_secret_missing_key_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """A password payload lacking the requested field is a clear failure."""
+    patch_setup_client(
+        item_sub_type='password',
+        secret_format='text',
+        secret_data='{"username": "myuser"}',
+    )
+
+    with pytest.raises(RuntimeError, match='not found in the password secret'):
+        akeyless_mod.akeyless_backend(**_backend_kwargs(secret_key='password'))
+
+
+def test_backend_pwd_secret_bad_key_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """Password secrets expose only their username and password fields."""
+    patch_setup_client(
+        item_sub_type='password',
+        secret_format='text',
+        secret_data='{"username": "myuser", "token": "nope"}',
+    )
+
+    with pytest.raises(NotImplementedError, match='"username" or "password"'):
+        akeyless_mod.akeyless_backend(**_backend_kwargs(secret_key='token'))
 
 
 def test_backend_pwd_secret_invalid_json_raises(
@@ -300,6 +385,31 @@ def test_backend_missing_json_key_raises(
         )
 
 
+def test_backend_structured_invalid_json_raises(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """A JSON-format secret holding malformed data is a clear failure."""
+    patch_setup_client(
+        secret_format='json',
+        secret_data='{"db_password": "s3cr3t"',
+    )
+
+    with pytest.raises(RuntimeError, match='Secret data not valid JSON'):
+        akeyless_mod.akeyless_backend(
+            **_backend_kwargs(secret_key='db_password'),
+        )
+
+
+def test_backend_path_missing_in_response(
+    patch_setup_client: _MockApiFactory,
+) -> None:
+    """A response that omits the requested path should name that path."""
+    patch_setup_client(secret_path='/some/other/secret')
+
+    with pytest.raises(RuntimeError, match=f'No secret data.*{_SECRET_PATH}'):
+        akeyless_mod.akeyless_backend(**_backend_kwargs())
+
+
 # ---------------------------------------------------------------------------
 # akeyless_ssh_backend - SSH certificate plugin
 # ---------------------------------------------------------------------------
@@ -359,7 +469,72 @@ def test_ssh_api_exc_wraps_runtime(
 
 
 # ---------------------------------------------------------------------------
-# _coerce_ttl helper
+# CA certificate handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'ca_cert_path',
+    (
+        pytest.param(None, id='no-ca-cert'),
+        pytest.param('/opt/certs/ca.pem', id='ca-cert'),
+    ),
+)
+def test_setup_client_configuration(ca_cert_path: str | None) -> None:
+    """The client identifies itself as AWX and honours a CA certificate."""
+    # WPS437: private helper, tested directly here intentionally
+    # pylint: disable-next=protected-access
+    api_client = akeyless_mod._setup_client(  # noqa: WPS437
+        _GATEWAY_URL,
+        ca_cert_path,
+    ).api_client
+
+    assert api_client.user_agent == 'AWX'
+    assert api_client.default_headers['akeylessclienttype'] == 'AWX'
+    assert api_client.configuration.host == _GATEWAY_URL
+    assert api_client.configuration.ssl_ca_cert == ca_cert_path
+
+
+@pytest.mark.parametrize(
+    ('backend', 'backend_kwargs'),
+    (
+        pytest.param(
+            akeyless_mod.akeyless_backend,
+            _backend_kwargs(ca_cert=_CA_CERT_PEM),
+            id='secret',
+        ),
+        pytest.param(
+            akeyless_mod.akeyless_ssh_backend,
+            _ssh_kwargs(ca_cert=_CA_CERT_PEM),
+            id='ssh',
+        ),
+    ),
+)
+def test_backend_ca_cert_reaches_client(
+    backend: Callable[..., str],
+    backend_kwargs: dict[str, object],
+    patch_setup_client: _MockApiFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A CA certificate should reach the client as a file on disk."""
+    mock_api = patch_setup_client()
+    written_certs: list[str] = []
+
+    def _capture_ca_cert(_gateway_url: str, ca_cert_path: str) -> object:
+        written_certs.append(
+            pathlib.Path(ca_cert_path).read_text(encoding='utf-8'),
+        )
+        return mock_api
+
+    monkeypatch.setattr(akeyless_mod, '_setup_client', _capture_ca_cert)
+
+    backend(**backend_kwargs)
+
+    assert written_certs == [_CA_CERT_PEM]
+
+
+# ---------------------------------------------------------------------------
+# _coerce_ttl and _resolve_gateway_url helpers
 # ---------------------------------------------------------------------------
 
 
@@ -388,6 +563,40 @@ def test_coerce_ttl_invalid_raises() -> None:
         # WPS437: _coerce_ttl is private but is tested directly here intentionally
         # pylint: disable-next=protected-access
         akeyless_mod._coerce_ttl('not-a-number')  # noqa: WPS437
+
+
+@pytest.mark.parametrize(
+    ('gateway_kwargs', 'expected'),
+    (
+        pytest.param(
+            {'gateway_url': f'{_GATEWAY_URL}/'},
+            _GATEWAY_URL,
+            id='trailing-slash-stripped',
+        ),
+        pytest.param(
+            {'gateway_url': 'https://my.gw/api/v2///'},
+            'https://my.gw/api/v2',
+            id='repeated-slashes-stripped',
+        ),
+        pytest.param(
+            {'url': f'{_GATEWAY_URL}/', 'gateway_url': 'https://stale.gw'},
+            _GATEWAY_URL,
+            id='oidc-url-wins',
+        ),
+    ),
+)
+def test_resolve_gateway_url(
+    gateway_kwargs: dict[str, str],
+    expected: str,
+) -> None:
+    """_resolve_gateway_url should prefer `url` and drop trailing slashes."""
+    # WPS437: private helper, tested directly here intentionally
+    # pylint: disable-next=protected-access
+    resolved_url = akeyless_mod._resolve_gateway_url(  # noqa: WPS437
+        gateway_kwargs,
+    )
+
+    assert resolved_url == expected
 
 
 # ---------------------------------------------------------------------------
@@ -481,9 +690,13 @@ def test_oidc_plugins_workload_contract(
 
     It only injects a token into credential types exposing an internal
     ``workload_identity_token`` field, and it reads the audience of that
-    token from the input named ``url``.
+    token from the input named ``url``. A second URL input would make the
+    audience ambiguous, so ``gateway_url`` must be absent.
     """
     fields = plugin.inputs['fields']
+    declared_ids = {field['id'] for field in fields} | set(
+        plugin.inputs['required'],
+    )
     token_fields = [
         field for field in fields if field['id'] == 'workload_identity_token'
     ]
@@ -492,4 +705,4 @@ def test_oidc_plugins_workload_contract(
     assert len(token_fields) == 1
     assert token_fields[0]['internal'] is True
     assert token_fields[0]['secret'] is True
-    assert 'access_key' not in {field['id'] for field in fields}
+    assert not declared_ids & {'access_key', 'gateway_url'}

--- a/tests/importable_test.py
+++ b/tests/importable_test.py
@@ -90,6 +90,16 @@ credential_plugins = (
         'akeyless_ssh',
         'awx_plugins.credentials.akeyless:akeyless_ssh_plugin',
     ),
+    EntryPointParam(
+        'awx_plugins.credentials',
+        'akeyless-oidc',
+        'awx_plugins.credentials.akeyless:akeyless_oidc_plugin',
+    ),
+    EntryPointParam(
+        'awx_plugins.credentials',
+        'akeyless-ssh-oidc',
+        'awx_plugins.credentials.akeyless:akeyless_ssh_oidc_plugin',
+    ),
 )
 
 

--- a/tests/importable_test.py
+++ b/tests/importable_test.py
@@ -80,6 +80,16 @@ credential_plugins = (
         'aws_secretsmanager_credential',
         'awx_plugins.credentials.aws_secretsmanager:aws_secretmanager_plugin',
     ),
+    EntryPointParam(
+        'awx_plugins.credentials',
+        'akeyless',
+        'awx_plugins.credentials.akeyless:akeyless_plugin',
+    ),
+    EntryPointParam(
+        'awx_plugins.credentials',
+        'akeyless_ssh',
+        'awx_plugins.credentials.akeyless:akeyless_ssh_plugin',
+    ),
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,8 @@ extras =
   credentials-thycotic-dsv
   credentials-thycotic-tss
   credentials-aws-secretsmanager-credential
+  credentials-akeyless
+  credentials-akeyless-ssh
   inventory-azure-rm
   inventory-ec2
   inventory-gce


### PR DESCRIPTION
## Summary

Adds four Akeyless credential plugins:

| Entry point | Credential type | Authentication |
| --- | --- | --- |
| `akeyless` | Akeyless | API key |
| `akeyless_ssh` | Akeyless SSH | API key |
| `akeyless-oidc` | Akeyless (OIDC) | Workload identity token |
| `akeyless-ssh-oidc` | Akeyless SSH (OIDC) | Workload identity token |

The API key plugins cover static secret lookup (text, JSON and key-value formats) and signed SSH certificate issuance.

The OIDC plugins follow the `hashivault-kv-oidc` / `hashivault-ssh-oidc` pattern: they reuse the same backends and differ only in their inputs, exposing the internal `workload_identity_token` field, dropping `access_key`, and naming the endpoint field `url` since the controller reads the audience of the minted token from the input of that exact name. `access_id` on those types identifies the Akeyless JWT auth method that trusts the platform as an OIDC issuer.

Authentication selects the auth material at call time, preferring a workload identity token (exchanged via the SDK's `jwt` access type) and falling back to the API key, so the API key plugins are unchanged.

This supersedes #147, which could not be reopened.

## Companion PR

The OIDC types also need ansible/awx#16562. `_is_oidc_namespace_disabled()` filters against the hardcoded `OIDC_CREDENTIAL_TYPE_NAMESPACES` list, so without that change these types stay visible when `FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED` is off and fail at job launch instead of being hidden.

## Test plan

- [x] Unit tests for both auth paths, secret formats, SSH issuance and error handling (24 tests, 90% coverage of the module)
- [x] A test pinning the two contract details the controller depends on: the internal `workload_identity_token` field and the input named `url`
- [x] `pre-commit` clean: flake8/wemake, pylint, mypy on 3.11/3.12/3.13
- [x] End to end on AAP 2.7.1 (controller 4.8.3, `awx-plugins-core` 0.1.dev3822+g5d80fc116):
  - `POST /api/v2/credentials/<id>/test/` returns 202 with the expected `aud` and `aap_controller_*` claims
  - A job resolves a Machine credential's `password` from Akeyless via the workload identity token
  - Negative control: an invalid secret path fails the job with a traceback terminating in `akeyless_backend`, confirming the lookup is in the execution path

Made with [Cursor](https://cursor.com)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Akeyless integrations for retrieving secrets and generating SSH certificates.
  * Added access-key and OIDC/workload-identity authentication.
  * Added support for text, JSON, and key-value secret formats, optional CA verification, and SSH certificate TTLs.
  * Added plugin discovery and installation options.

* **Documentation**
  * Updated documentation tooling to recognize Akeyless terminology and references.

* **Tests**
  * Added comprehensive coverage for retrieval, authentication, SSH certificates, OIDC, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->