### PR TITLE
Gate Coveralls upload to the upstream repo to unblock fork CI

### DIFF
--- a/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-job/action.yml
+++ b/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-job/action.yml
@@ -35,7 +35,16 @@ runs:
     uses: coverallsapp/github-action@v2
     with:
       debug: ${{ runner.debug == 1 && true || false }}
-      fail-on-error: ${{ runner.debug == 1 && false || true }}
+      # NOTE: Only require the upload to succeed in the upstream repo,
+      # NOTE: since forks are not registered on Coveralls.
+      fail-on-error: >-
+        ${{
+          runner.debug != 1
+          && fromJSON(
+            inputs.job-dependencies-context
+          ).pre-setup.outputs.upstream-repository-id
+          == github.repository_id
+        }}
       files: >-
         ${{
           fromJSON(

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -406,6 +406,8 @@ jobs:
         }}
       dists-artifact-name: >-
         ${{ needs.pre-setup.outputs.dists-artifact-name }}
+      job-dependencies-context: >-  # context for hooks
+        ${{ toJSON(needs) }}
       post-toxenv-preparation-command: >-
         ${{
           matrix.toxenv == 'pre-commit'

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![PyPI Badge]][PyPI]
 [![PyPI Supported Versions Badge]][PyPI Supported Versions]
 [![Codecov Badge]][Codecov]
-[![Coveralls Badge]][Coveralls]
 [![Code of Conduct Badge]][Code of Conduct]
 [![Apache v2 License Badge]][Apache v2 License]
 [![Ansible Matrix Badge]][Ansible Matrix]
@@ -30,11 +29,6 @@ https://results.pre-commit.ci/latest/github/ansible/awx-plugins/devel
 https://codecov.io/gh/ansible/awx-plugins/branch/devel/graph/badge.svg?flag=pytest
 [Codecov]:
 https://app.codecov.io/gh/ansible/awx-plugins?flags[]=pytest
-
-[Coveralls Badge]:
-https://coveralls.io/repos/github/ansible/awx-plugins/badge.svg?branch=devel
-[Coveralls]:
-https://coveralls.io/github/ansible/awx-plugins?branch=devel
 
 [Code of Conduct Badge]: https://img.shields.io/badge/code%20of%20conduct-Ansible-yellow.svg
 [Code of Conduct]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html


### PR DESCRIPTION
## Summary

Fork CI is currently red on every branch (including `devel`): pre-commit hooks all pass, but the job fails uploading MyPy coverage to Coveralls with `Unprocessable Entity / Couldn't find a repository matching this job`, since forks aren't registered on coveralls.io.

This makes the Coveralls upload's `fail-on-error` true only when the run is happening in the upstream repo (`pre-setup.outputs.upstream-repository-id == github.repository_id`), mirroring the Codecov gate the tests job already uses. `job-dependencies-context: ${{ toJSON(needs) }}` is forwarded into the lint job so the hook can read that `pre-setup` output.

In forks, the upload still attempts but its rejection no longer fails the job. Since `ansible/awx-plugins`'s repo id equals `UPSTREAM_REPOSITORY_ID`, the gate always evaluates to true here — this is a **behavioral no-op on this repo**: strict enforcement is preserved upstream, and only forks stop failing CI on the Coveralls step.

## Test plan

- [x] `pre-commit run` on the two changed files — all hooks pass except a pre-existing `actionlint`/pyflakes false positive on `ci-cd.yml:245` (an unrelated inline Python script) that is also present on unmodified `devel`.
- [x] Confirmed `ansible/awx-plugins`'s repository id matches `UPSTREAM_REPOSITORY_ID`, so the gate is unchanged (`true`) on this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of code coverage upload failures, allowing debug and forked runs to continue while enforcing uploads for standard upstream runs.

* **Chores**
  * Enhanced continuous integration workflow context handling for linting jobs.
  * Removed the Coveralls status badge and related links from the project documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->