### PR TITLE
Remove Coveralls integration

### DIFF
--- a/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-job/action.yml
+++ b/.github/reusables/tox-dev/workflow/reusable-tox/hooks/post-tox-job/action.yml
@@ -25,28 +25,8 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Log uploading MyPy coverage reports to Coveralls
-    if: fromJSON(inputs.calling-job-context).toxenv == 'pre-commit'
-    run: >-
-      >&2 echo Uploading MyPy coverage reports to Coveralls...
+  - name: No-op (Coveralls integration removed)
+    run: 'true'
     shell: bash
-  - name: Send coverage data to Coveralls
-    if: fromJSON(inputs.calling-job-context).toxenv == 'pre-commit'
-    uses: coverallsapp/github-action@v2
-    with:
-      debug: ${{ runner.debug == 1 && true || false }}
-      fail-on-error: ${{ runner.debug == 1 && false || true }}
-      files: >-
-        ${{
-          fromJSON(
-            inputs.current-job-steps
-          ).tox-run.outputs.coveralls-report-files
-        }}
-      flag-name: >-
-        ${{
-          fromJSON(inputs.current-job-steps).tox-run.outputs.coveralls-flags
-        }}
-      format: cobertura
-      measure: ${{ runner.debug == 1 && true || false }}
 
 ...

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![PyPI Badge]][PyPI]
 [![PyPI Supported Versions Badge]][PyPI Supported Versions]
 [![Codecov Badge]][Codecov]
-[![Coveralls Badge]][Coveralls]
 [![Code of Conduct Badge]][Code of Conduct]
 [![Apache v2 License Badge]][Apache v2 License]
 [![Ansible Matrix Badge]][Ansible Matrix]
@@ -31,10 +30,6 @@ https://codecov.io/gh/ansible/awx-plugins/branch/devel/graph/badge.svg?flag=pyte
 [Codecov]:
 https://app.codecov.io/gh/ansible/awx-plugins?flags[]=pytest
 
-[Coveralls Badge]:
-https://coveralls.io/repos/github/ansible/awx-plugins/badge.svg?branch=devel
-[Coveralls]:
-https://coveralls.io/github/ansible/awx-plugins?branch=devel
 
 [Code of Conduct Badge]: https://img.shields.io/badge/code%20of%20conduct-Ansible-yellow.svg
 [Code of Conduct]: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html

--- a/tox.ini
+++ b/tox.ini
@@ -258,28 +258,6 @@ commands_post =
     {[python-cli-options]max-isolation} \
     {[python-cli-options]warnings-to-errors} \
     -c \
-      'import os, pathlib, sys; \
-      os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
-      project_root_path = pathlib.Path(r"{toxinidir}"); \
-      test_results_dir = pathlib.Path(r"{temp_dir}") / ".test-results"; \
-      coverage_result_files = " ".join(\
-        str(xml_path.relative_to(project_root_path)) \
-        for xml_path in test_results_dir.glob("mypy--py-*{/}cobertura.xml")\
-      ); \
-      gh_output_fd = open(\
-        os.environ["GITHUB_OUTPUT"], encoding="utf-8", mode="a",\
-      ); \
-      print(\
-        f"coveralls-report-files={coverage_result_files !s}", \
-        file=gh_output_fd, \
-      ); \
-      print("coveralls-flags=MyPy", file=gh_output_fd); \
-      gh_output_fd.close()'
-  {envpython} \
-    {[python-cli-options]byte-errors} \
-    {[python-cli-options]max-isolation} \
-    {[python-cli-options]warnings-to-errors} \
-    -c \
       'import itertools, os, pathlib, shlex, sys; \
       os.getenv("GITHUB_ACTIONS") == "true" or sys.exit(); \
       test_results_dir = pathlib.Path(r"{temp_dir}") / ".test-results"; \


### PR DESCRIPTION
## Summary
- Remove Coveralls badge and link definitions from README
- Remove Coveralls output variable computation from tox.ini `commands_post`
- Replace Coveralls upload steps in post-tox-job action with no-op

The Coveralls project page returns 403, which breaks the `linkcheck-docs` CI
job (and cascades to the `check` / alls-green gate) on every PR.

## SonarCloud follow-up
SonarCloud is not yet configured for awx-plugins. To set it up (following AWX's pattern):
1. Create the project in the `ansible` SonarCloud org
2. Add `sonar-project.properties` to the repo root
3. Add a `sonarcloud_pr.yml` workflow (can adapt from AWX's `.github/workflows/sonarcloud_pr.yml`)
4. `CICD_ORG_SONAR_TOKEN_CICD_BOT` secret should already be available at org level

Codecov integration is unaffected by this change.

## Test plan
- [ ] CI `linkcheck-docs` job passes (no more 403 from Coveralls)
- [ ] `alls-green` / `check` gate passes
- [ ] Coverage badge still shows (Codecov badge is retained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Coveralls coverage reporting and upload steps from automated checks.
  * Removed the Coveralls badge and related links from the project documentation.
  * Continued publishing MyPy JSON and text reports to the GitHub Actions summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->